### PR TITLE
#4 [FEAT] 깃허브 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,10 @@ dependencies {
 	implementation("software.amazon.awssdk:s3:2.21.0")
     //jpa
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	// Spring Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	// Spring OAuth2 Client
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
 }
 

--- a/src/main/java/org/autorepo/server/ServerApplication.java
+++ b/src/main/java/org/autorepo/server/ServerApplication.java
@@ -2,8 +2,10 @@ package org.autorepo.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class ServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/org/autorepo/server/domain/user/entity/User.java
+++ b/src/main/java/org/autorepo/server/domain/user/entity/User.java
@@ -1,13 +1,16 @@
 package org.autorepo.server.domain.user.entity;
 
 import jakarta.persistence.*;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.autorepo.server.domain.repo.entity.Repo;
 import org.autorepo.server.global.common.BaseTimeEntity;
 
 import java.util.List;
 
-
+@Builder
+@Getter
+@Setter
+@AllArgsConstructor
 @NoArgsConstructor
 @Table(name = "user")
 @Entity

--- a/src/main/java/org/autorepo/server/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/autorepo/server/domain/user/repository/UserRepository.java
@@ -4,5 +4,8 @@ import org.autorepo.server.domain.repo.entity.Repo;
 import org.autorepo.server.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByGithubId(String githubId);
 }

--- a/src/main/java/org/autorepo/server/domain/user/service/CustomOAuth2UserService.java
+++ b/src/main/java/org/autorepo/server/domain/user/service/CustomOAuth2UserService.java
@@ -1,0 +1,42 @@
+package org.autorepo.server.domain.user.service;
+
+import org.autorepo.server.domain.user.entity.User;
+import org.autorepo.server.domain.user.entity.UserRole;
+import org.autorepo.server.domain.user.repository.UserRepository;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+
+    public CustomOAuth2UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        // GitHub의 email 필드를 가져오되, null이면 login으로 대체
+        String githubEmail = oAuth2User.getAttribute("email");
+        if (githubEmail == null) {
+            githubEmail = oAuth2User.getAttribute("login");
+        }
+
+        User user = userRepository.findByGithubId(githubEmail).orElse(null);
+        if (user == null) {
+            user = User.builder()
+                    .githubId(githubEmail)
+                    .userRole(UserRole.USER)
+                    .build();
+            userRepository.save(user);
+        }
+
+        return new DefaultOAuth2User(oAuth2User.getAuthorities(), oAuth2User.getAttributes(), "id");
+    }
+}

--- a/src/main/java/org/autorepo/server/domain/user/service/OAuth2FailureHandler.java
+++ b/src/main/java/org/autorepo/server/domain/user/service/OAuth2FailureHandler.java
@@ -1,0 +1,22 @@
+package org.autorepo.server.domain.user.service;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class OAuth2FailureHandler implements AuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+        response.getWriter().write("{\"error\": \"Authentication failed\", \"message\": \"" + exception.getMessage() + "\"}");
+    }
+}
+

--- a/src/main/java/org/autorepo/server/domain/user/service/OAuth2SuccessHandler.java
+++ b/src/main/java/org/autorepo/server/domain/user/service/OAuth2SuccessHandler.java
@@ -1,0 +1,21 @@
+package org.autorepo.server.domain.user.service;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setContentType("application/json");
+        response.getWriter().write("{\"success\": true, \"message\": \"Authentication successful\"}");
+    }
+}

--- a/src/main/java/org/autorepo/server/global/config/SecurityConfig.java
+++ b/src/main/java/org/autorepo/server/global/config/SecurityConfig.java
@@ -1,0 +1,36 @@
+package org.autorepo.server.global.config;
+
+import org.autorepo.server.domain.user.service.OAuth2FailureHandler;
+import org.autorepo.server.domain.user.service.OAuth2SuccessHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/admin/**").hasRole("ADMIN")
+                        .requestMatchers("/favicon.ico").permitAll()
+                        .anyRequest().permitAll()
+                )
+                .oauth2Login(oauth2 -> oauth2
+                        .successHandler(new OAuth2SuccessHandler())
+                        .failureHandler(new OAuth2FailureHandler())
+                );
+        return http.build();
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService() {
+        return username -> {
+            throw new UnsupportedOperationException("UserDetailsService is not used in this app.");
+        };
+    }
+}

--- a/src/main/java/org/autorepo/server/global/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/org/autorepo/server/global/error/handler/GlobalExceptionHandler.java
@@ -19,7 +19,7 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 public class GlobalExceptionHandler {
 
     /**
-     * @Valid 유효성 검사 실패 처리
+     * @ Valid 유효성 검사 실패 처리
      */
     @ExceptionHandler(MethodArgumentNotValidException.class)
     protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {

--- a/src/main/java/org/autorepo/server/global/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/org/autorepo/server/global/error/handler/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import org.autorepo.server.global.error.dto.ErrorResponse;
 import org.autorepo.server.global.error.exception.BusinessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.validation.BindException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -66,6 +67,17 @@ public class GlobalExceptionHandler {
         final ErrorCode errorCode = e.getErrorCode();
         final ErrorResponse errorBaseResponse = ErrorResponse.of(errorCode);
         return ResponseEntity.status(errorCode.getHttpStatus()).body(errorBaseResponse);
+    }
+
+    /**
+     * 인증 실패 처리
+     */
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<ErrorResponse> handleAuthenticationException(AuthenticationException e) {
+        log.error(">>> handle: AuthenticationException ", e);
+        final ErrorCode errorCode = ErrorCode.UNAUTHORIZED;
+        final ErrorResponse errorResponse = ErrorResponse.of(errorCode);
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(errorResponse);
     }
 
     /**


### PR DESCRIPTION
## 관련 이슈

[//]: # (해결한 문제를 지정하는 Issue Index에 연결해야 합니다.)

- Resolves : #4 

## 작업 사항

[//]: # (해당 Pull Request에서 수행한 작업 목록을 제시해야 합니다.)

- 깃허브 로그인을 구현했습니다.
<img width="1146" alt="스크린샷 2024-11-16 오후 7 31 59" src="https://github.com/user-attachments/assets/b7a012f7-9460-47eb-b938-a6046dc8c23c">  

<br/>

- 깃허브 유저 본인 설정 상에서 이메일 공개를 설정해두지 않은 경우, 불러올 수가 없는 걸로 확인돼서 이메일 공개가 된 경우에는 이메일을 저장하고, null인 경우 아이디를 저장하도록 했는데, 통일성이 있는 편이 더 적합할 것 같으면 전부 아이디만 불러오는 것으로 수정하겠습니다
https://github.com/2024-2-3M1S/AutoRepo-Server/blob/3e8636c2790c7ceff511bd158fbf0c28e33bb73e/src/main/java/org/autorepo/server/domain/user/service/CustomOAuth2UserService.java#L25-L29

<br/>

- SpringSecurity에서 이 부분은 favicon.ico가 없다는 오류가 발생해서 추가해줬습니다
https://github.com/2024-2-3M1S/AutoRepo-Server/blob/3e8636c2790c7ceff511bd158fbf0c28e33bb73e/src/main/java/org/autorepo/server/global/config/SecurityConfig.java#L20

## 참고 사항

[//]: # (기능을 만들 때 생긴 이슈에 대해서 다른사람들이 참고해야 할 사항을 적습니다.)

- yml 수정 후 노션에 업로드했습니다.
- http://localhost:8080/oauth2/authorization/github 요청은 이 링크로 보내보시면 됩니다!