### PR TITLE
#9 [FEAT]  PR/ISSUE 템플릿 관련 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	// Spring OAuth2 Client
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    //json
+    implementation 'org.json:json:20230227'
+
 
 }
 

--- a/src/main/java/org/autorepo/server/domain/repo/repository/RepoRepository.java
+++ b/src/main/java/org/autorepo/server/domain/repo/repository/RepoRepository.java
@@ -4,5 +4,8 @@ import org.autorepo.server.domain.label.entity.Label;
 import org.autorepo.server.domain.repo.entity.Repo;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface RepoRepository extends JpaRepository<Repo, Long> {
+    Optional<Repo> findByRepoUrl(String repoUrl);
 }

--- a/src/main/java/org/autorepo/server/domain/template/controller/TemplateController.java
+++ b/src/main/java/org/autorepo/server/domain/template/controller/TemplateController.java
@@ -1,8 +1,9 @@
 package org.autorepo.server.domain.template.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.autorepo.server.domain.template.dto.request.CreateTemplateRequestDto;
+import org.autorepo.server.domain.template.dto.request.ShareTemplateRequestDto;
 import org.autorepo.server.domain.template.dto.request.TemplateListResponseDto;
+import org.autorepo.server.domain.template.dto.request.UploadTemplateRequestDto;
 import org.autorepo.server.domain.template.entity.TemplateType;
 import org.autorepo.server.domain.template.service.TemplateService;
 import org.autorepo.server.global.common.SuccessResponse;
@@ -19,11 +20,17 @@ public class TemplateController {
     private final TemplateService templateService;
 
     @PostMapping("/upload")
-    public ResponseEntity<SuccessResponse<?>> uploadTemplate(@RequestBody CreateTemplateRequestDto createTemplateRequestDto) {
-        templateService.uploadTemplate(createTemplateRequestDto);
-        templateService.saveTemplate(createTemplateRequestDto);
+    public ResponseEntity<SuccessResponse<?>> uploadTemplate(@RequestBody UploadTemplateRequestDto uploadTemplateRequestDto) {
+        templateService.uploadTemplate(uploadTemplateRequestDto);
         return SuccessResponse.created(null);
     }
+
+    @PostMapping("/share")
+    public ResponseEntity<SuccessResponse<?>> shareTemplate(@RequestBody ShareTemplateRequestDto shareTemplateRequestDto) {
+        templateService.saveTemplate(shareTemplateRequestDto);
+        return SuccessResponse.created(null);
+    }
+
 
     @GetMapping("/{type}")
     public ResponseEntity<SuccessResponse<?>> getAllTemplate(@PathVariable TemplateType type) {

--- a/src/main/java/org/autorepo/server/domain/template/controller/TemplateController.java
+++ b/src/main/java/org/autorepo/server/domain/template/controller/TemplateController.java
@@ -20,6 +20,7 @@ public class TemplateController {
     @PostMapping("/upload")
     public ResponseEntity<SuccessResponse<?>> uploadTemplate(@RequestBody CreateTemplateRequestDto createTemplateRequestDto) {
         templateService.uploadTemplate(createTemplateRequestDto);
+        templateService.saveTemplate(createTemplateRequestDto);
         return SuccessResponse.created(null);
     }
 }

--- a/src/main/java/org/autorepo/server/domain/template/controller/TemplateController.java
+++ b/src/main/java/org/autorepo/server/domain/template/controller/TemplateController.java
@@ -1,11 +1,25 @@
 package org.autorepo.server.domain.template.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.autorepo.server.domain.template.dto.request.CreateTemplateRequestDto;
+import org.autorepo.server.domain.template.service.TemplateService;
+import org.autorepo.server.global.common.SuccessResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/template")
 @RestController
-public class TemplateController{
+public class TemplateController {
+
+    private final TemplateService templateService;
+
+    @PostMapping("/upload")
+    public ResponseEntity<SuccessResponse<?>> uploadTemplate(@RequestBody CreateTemplateRequestDto createTemplateRequestDto) {
+        templateService.uploadTemplate(createTemplateRequestDto);
+        return SuccessResponse.created(null);
+    }
 }

--- a/src/main/java/org/autorepo/server/domain/template/controller/TemplateController.java
+++ b/src/main/java/org/autorepo/server/domain/template/controller/TemplateController.java
@@ -2,13 +2,14 @@ package org.autorepo.server.domain.template.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.autorepo.server.domain.template.dto.request.CreateTemplateRequestDto;
+import org.autorepo.server.domain.template.dto.request.TemplateListResponseDto;
+import org.autorepo.server.domain.template.entity.TemplateType;
 import org.autorepo.server.domain.template.service.TemplateService;
 import org.autorepo.server.global.common.SuccessResponse;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/template")
@@ -22,5 +23,11 @@ public class TemplateController {
         templateService.uploadTemplate(createTemplateRequestDto);
         templateService.saveTemplate(createTemplateRequestDto);
         return SuccessResponse.created(null);
+    }
+
+    @GetMapping("/{type}")
+    public ResponseEntity<SuccessResponse<?>> getAllTemplate(@PathVariable TemplateType type) {
+        List<TemplateListResponseDto> templateListResponseDto = templateService.getAllTemplate(type);
+        return SuccessResponse.ok(templateListResponseDto);
     }
 }

--- a/src/main/java/org/autorepo/server/domain/template/dto/request/CreateTemplateRequestDto.java
+++ b/src/main/java/org/autorepo/server/domain/template/dto/request/CreateTemplateRequestDto.java
@@ -1,9 +1,11 @@
 package org.autorepo.server.domain.template.dto.request;
 
+import org.autorepo.server.domain.template.entity.TemplateType;
+
 public record CreateTemplateRequestDto(
         Long userId,
         String repoUrl,
-        String type,
+        TemplateType type,
         String content
 ) {
 }

--- a/src/main/java/org/autorepo/server/domain/template/dto/request/CreateTemplateRequestDto.java
+++ b/src/main/java/org/autorepo/server/domain/template/dto/request/CreateTemplateRequestDto.java
@@ -1,0 +1,9 @@
+package org.autorepo.server.domain.template.dto.request;
+
+public record CreateTemplateRequestDto(
+        Long userId,
+        String repoUrl,
+        String content,
+        String type
+) {
+}

--- a/src/main/java/org/autorepo/server/domain/template/dto/request/CreateTemplateRequestDto.java
+++ b/src/main/java/org/autorepo/server/domain/template/dto/request/CreateTemplateRequestDto.java
@@ -3,7 +3,7 @@ package org.autorepo.server.domain.template.dto.request;
 public record CreateTemplateRequestDto(
         Long userId,
         String repoUrl,
-        String content,
-        String type
+        String type,
+        String content
 ) {
 }

--- a/src/main/java/org/autorepo/server/domain/template/dto/request/ShareTemplateRequestDto.java
+++ b/src/main/java/org/autorepo/server/domain/template/dto/request/ShareTemplateRequestDto.java
@@ -1,0 +1,11 @@
+package org.autorepo.server.domain.template.dto.request;
+
+import org.autorepo.server.domain.template.entity.TemplateType;
+
+public record ShareTemplateRequestDto(
+        Long userId,
+        TemplateType type,
+        String title,
+        String content
+) {
+}

--- a/src/main/java/org/autorepo/server/domain/template/dto/request/TemplateListResponseDto.java
+++ b/src/main/java/org/autorepo/server/domain/template/dto/request/TemplateListResponseDto.java
@@ -1,0 +1,15 @@
+package org.autorepo.server.domain.template.dto.request;
+
+import org.autorepo.server.domain.template.entity.Template;
+
+public record TemplateListResponseDto(
+        Long templateId,
+        String content
+) {
+    public static TemplateListResponseDto of(Template template) {
+        return new TemplateListResponseDto(
+                template.getTemplateId(),
+                template.getContent()
+        );
+    }
+}

--- a/src/main/java/org/autorepo/server/domain/template/dto/request/UploadTemplateRequestDto.java
+++ b/src/main/java/org/autorepo/server/domain/template/dto/request/UploadTemplateRequestDto.java
@@ -2,7 +2,7 @@ package org.autorepo.server.domain.template.dto.request;
 
 import org.autorepo.server.domain.template.entity.TemplateType;
 
-public record CreateTemplateRequestDto(
+public record UploadTemplateRequestDto(
         Long userId,
         String repoUrl,
         TemplateType type,

--- a/src/main/java/org/autorepo/server/domain/template/entity/Template.java
+++ b/src/main/java/org/autorepo/server/domain/template/entity/Template.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.autorepo.server.domain.repo.entity.Repo;
 
+@Getter
 @AllArgsConstructor
 @Builder
 @NoArgsConstructor

--- a/src/main/java/org/autorepo/server/domain/template/entity/Template.java
+++ b/src/main/java/org/autorepo/server/domain/template/entity/Template.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.autorepo.server.domain.repo.entity.Repo;
 
+@AllArgsConstructor
+@Builder
 @NoArgsConstructor
 @Table(name = "template")
 @Entity

--- a/src/main/java/org/autorepo/server/domain/template/entity/Template.java
+++ b/src/main/java/org/autorepo/server/domain/template/entity/Template.java
@@ -15,6 +15,7 @@ public class Template {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long templateId;
+    private String title;
     @Enumerated(EnumType.STRING)
     private TemplateType type;
     @Column(columnDefinition = "TEXT")

--- a/src/main/java/org/autorepo/server/domain/template/repository/TemplateRepository.java
+++ b/src/main/java/org/autorepo/server/domain/template/repository/TemplateRepository.java
@@ -2,10 +2,12 @@ package org.autorepo.server.domain.template.repository;
 
 import org.autorepo.server.domain.repo.entity.Repo;
 import org.autorepo.server.domain.template.entity.Template;
+import org.autorepo.server.domain.template.entity.TemplateType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface TemplateRepository extends JpaRepository<Template, Long> {
     Optional<Template> findByRepoAndContent(Repo repo, String content);
+    Optional<Template> findAllByType(TemplateType type);
 }

--- a/src/main/java/org/autorepo/server/domain/template/repository/TemplateRepository.java
+++ b/src/main/java/org/autorepo/server/domain/template/repository/TemplateRepository.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface TemplateRepository extends JpaRepository<Template, Long> {
-    Optional<Template> findByRepoAndContent(Repo repo, String content);
+    Optional<Template> findByTitleAndContent(String title, String content);
+
     List<Template> findAllByType(TemplateType type);
 }

--- a/src/main/java/org/autorepo/server/domain/template/repository/TemplateRepository.java
+++ b/src/main/java/org/autorepo/server/domain/template/repository/TemplateRepository.java
@@ -5,9 +5,10 @@ import org.autorepo.server.domain.template.entity.Template;
 import org.autorepo.server.domain.template.entity.TemplateType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface TemplateRepository extends JpaRepository<Template, Long> {
     Optional<Template> findByRepoAndContent(Repo repo, String content);
-    Optional<Template> findAllByType(TemplateType type);
+    List<Template> findAllByType(TemplateType type);
 }

--- a/src/main/java/org/autorepo/server/domain/template/repository/TemplateRepository.java
+++ b/src/main/java/org/autorepo/server/domain/template/repository/TemplateRepository.java
@@ -4,5 +4,8 @@ import org.autorepo.server.domain.repo.entity.Repo;
 import org.autorepo.server.domain.template.entity.Template;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface TemplateRepository extends JpaRepository<Template, Long> {
+    Optional<Template> findByRepoAndContent(Repo repo, String content);
 }

--- a/src/main/java/org/autorepo/server/domain/template/service/TemplateService.java
+++ b/src/main/java/org/autorepo/server/domain/template/service/TemplateService.java
@@ -1,11 +1,98 @@
 package org.autorepo.server.domain.template.service;
 
 import lombok.RequiredArgsConstructor;
+import org.autorepo.server.domain.template.dto.request.CreateTemplateRequestDto;
+import org.autorepo.server.domain.user.entity.User;
+import org.autorepo.server.domain.user.repository.UserRepository;
+import org.json.JSONObject;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
 
 @RequiredArgsConstructor
 @Service
-@Transactional
 public class TemplateService {
+
+    private static final String GITHUB_API_URL = "https://api.github.com/repos/%s/%s/contents/%s";
+    private static final String PR_TEMPLATE_PATH = ".github/pull_request_template.md";
+    private static final String ISSUE_TEMPLATE_PATH = ".github/ISSUE_TEMPLATE/issue_template.md";
+
+    private final UserRepository userRepository;
+
+    // PR/ISSUE 템플릿 업로드
+    public void uploadTemplate(CreateTemplateRequestDto createTemplateRequestDto) {
+
+        User user = userRepository.findById(createTemplateRequestDto.userId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 ID를 가진 사용자를 찾을 수 없습니다: " + createTemplateRequestDto.userId()));
+
+        //이슈 메타 데이터 정보 임시 고정
+        String metaContent = "---\nname: Issue template\nabout: Issue template\ntitle: ''\nlabels: ''\nassignees: ''\n---";
+        String content = metaContent  +"\n"+ createTemplateRequestDto.content();
+
+        String path = createTemplateRequestDto.type().equalsIgnoreCase("PR") ? PR_TEMPLATE_PATH : ISSUE_TEMPLATE_PATH;
+
+        saveFileToGitHub(createTemplateRequestDto.repoUrl(), path, content, createTemplateRequestDto.type(), user.getGithubToken());
+    }
+
+
+    // GitHub API 요청
+    public void saveFileToGitHub(String repoUrl, String path, String content, String type, String token) {
+        RestTemplate restTemplate = new RestTemplate();
+
+        String[] repoInfo = parseRepositoryUrl(repoUrl);
+        String owner = repoInfo[0];
+        String repo = repoInfo[1];
+        String url = String.format(GITHUB_API_URL, owner, repo, path);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + token);
+        headers.set("Content-Type", "application/json");
+
+        String sha = getFileShaIfExists(restTemplate, url, headers);
+        String base64Content = java.util.Base64.getEncoder().encodeToString(content.getBytes());
+
+        JSONObject jsonBody = new JSONObject();
+        jsonBody.put("message", "Update " + type + " Template");
+        jsonBody.put("content", base64Content);
+        if (sha != null) {
+            jsonBody.put("sha", sha);
+        }
+
+        HttpEntity<String> request = new HttpEntity<>(jsonBody.toString(), headers);
+
+        try {
+            ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.PUT, request, String.class);
+            if (!response.getStatusCode().is2xxSuccessful()) {
+                throw new RuntimeException("파일 저장 실패: " + response.getBody());
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("파일 저장 중 오류 발생: " + e.getMessage(), e);
+        }
+    }
+
+    // repo URL에서 owner와 repo 정보를 파싱
+    public String[] parseRepositoryUrl(String repoUrl) {
+        String[] parts = repoUrl.split("/");
+        if (parts.length < 5) {
+            throw new IllegalArgumentException("잘못된 저장소 URL 형식입니다.");
+        }
+        String owner = parts[3];
+        String repo = parts[4].replace(".git", "");
+        return new String[]{owner, repo};
+    }
+
+    // GitHub 저장소에서 SHA값 조회(이전 파일이 존재하는지 확인)
+    private String getFileShaIfExists(RestTemplate restTemplate, String url, HttpHeaders headers) {
+        try {
+            HttpEntity<Void> request = new HttpEntity<>(headers);
+            ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, request, String.class);
+            if (response.getStatusCode().is2xxSuccessful()) {
+                return new JSONObject(response.getBody()).getString("sha");
+            }
+        } catch (Exception ignored) {
+            return null;
+        }
+        return null;
+    }
+
 }

--- a/src/main/java/org/autorepo/server/domain/template/service/TemplateService.java
+++ b/src/main/java/org/autorepo/server/domain/template/service/TemplateService.java
@@ -3,8 +3,9 @@ package org.autorepo.server.domain.template.service;
 import lombok.RequiredArgsConstructor;
 import org.autorepo.server.domain.repo.entity.Repo;
 import org.autorepo.server.domain.repo.repository.RepoRepository;
-import org.autorepo.server.domain.template.dto.request.CreateTemplateRequestDto;
+import org.autorepo.server.domain.template.dto.request.ShareTemplateRequestDto;
 import org.autorepo.server.domain.template.dto.request.TemplateListResponseDto;
+import org.autorepo.server.domain.template.dto.request.UploadTemplateRequestDto;
 import org.autorepo.server.domain.template.entity.Template;
 import org.autorepo.server.domain.template.entity.TemplateType;
 import org.autorepo.server.domain.template.repository.TemplateRepository;
@@ -34,19 +35,19 @@ public class TemplateService {
     private final RepoRepository repoRepository;
 
     // PR/ISSUE 템플릿 업로드
-    public void uploadTemplate(CreateTemplateRequestDto createTemplateRequestDto) {
+    public void uploadTemplate(UploadTemplateRequestDto uploadTemplateRequestDto) {
 
-        User user = userRepository.findById(createTemplateRequestDto.userId())
-                .orElseThrow(() -> new IllegalArgumentException("해당 ID를 가진 사용자를 찾을 수 없습니다: " + createTemplateRequestDto.userId()));
+        User user = userRepository.findById(uploadTemplateRequestDto.userId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 ID를 가진 사용자를 찾을 수 없습니다: " + uploadTemplateRequestDto.userId()));
 
-        boolean isPR = createTemplateRequestDto.type() == TemplateType.PR;
+        boolean isPR = uploadTemplateRequestDto.type() == TemplateType.PR;
 
         //이슈 메타 데이터 정보 임시 고정
         String metaContent = "---\nname: Issue template\nabout: Issue template\ntitle: ''\nlabels: ''\nassignees: ''\n---";
-        String content = isPR ? createTemplateRequestDto.content() : metaContent + "\n" + createTemplateRequestDto.content();
+        String content = isPR ? uploadTemplateRequestDto.content() : metaContent + "\n" + uploadTemplateRequestDto.content();
         String path = isPR ? PR_TEMPLATE_PATH : ISSUE_TEMPLATE_PATH;
 
-        saveFileToGitHub(createTemplateRequestDto.repoUrl(), path, content, createTemplateRequestDto.type(), user.getGithubToken());
+        saveFileToGitHub(uploadTemplateRequestDto.repoUrl(), path, content, uploadTemplateRequestDto.type(), user.getGithubToken());
     }
 
 
@@ -111,18 +112,16 @@ public class TemplateService {
     }
 
     // 템플릿 저장
-    public void saveTemplate(CreateTemplateRequestDto createTemplateRequestDto) {
-        Repo repo = repoRepository.findByRepoUrl(createTemplateRequestDto.repoUrl())
-                .orElseThrow(() -> new IllegalArgumentException("해당 Repo를 찾을 수 없습니다: " + createTemplateRequestDto.repoUrl()));
+    public void saveTemplate(ShareTemplateRequestDto shareTemplateRequestDto) {
 
-        boolean templateExists = templateRepository.findByRepoAndContent(repo, createTemplateRequestDto.content())
+        boolean templateExists = templateRepository.findByTitleAndContent(shareTemplateRequestDto.title(), shareTemplateRequestDto.content())
                 .isPresent();
 
         if (!templateExists) {
             Template template = Template.builder()
-                    .content(createTemplateRequestDto.content())
-                    .type(createTemplateRequestDto.type())
-                    .repo(repo)
+                    .title(shareTemplateRequestDto.title())
+                    .content(shareTemplateRequestDto.content())
+                    .type(shareTemplateRequestDto.type())
                     .build();
 
             templateRepository.save(template);

--- a/src/main/java/org/autorepo/server/domain/template/service/TemplateService.java
+++ b/src/main/java/org/autorepo/server/domain/template/service/TemplateService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.autorepo.server.domain.repo.entity.Repo;
 import org.autorepo.server.domain.repo.repository.RepoRepository;
 import org.autorepo.server.domain.template.dto.request.CreateTemplateRequestDto;
+import org.autorepo.server.domain.template.dto.request.TemplateListResponseDto;
 import org.autorepo.server.domain.template.entity.Template;
 import org.autorepo.server.domain.template.entity.TemplateType;
 import org.autorepo.server.domain.template.repository.TemplateRepository;
@@ -16,6 +17,9 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -122,6 +126,14 @@ public class TemplateService {
 
             templateRepository.save(template);
         }
+    }
+
+    public List<TemplateListResponseDto> getAllTemplate(TemplateType type) {
+        List<Template> templates = templateRepository.findAllByType(type);
+
+        return templates.stream()
+                .map(TemplateListResponseDto::of)
+                .collect(Collectors.toList());
     }
 
 

--- a/src/main/java/org/autorepo/server/domain/template/service/TemplateService.java
+++ b/src/main/java/org/autorepo/server/domain/template/service/TemplateService.java
@@ -39,11 +39,12 @@ public class TemplateService {
         User user = userRepository.findById(createTemplateRequestDto.userId())
                 .orElseThrow(() -> new IllegalArgumentException("해당 ID를 가진 사용자를 찾을 수 없습니다: " + createTemplateRequestDto.userId()));
 
+        boolean isPR = createTemplateRequestDto.type() == TemplateType.PR;
+
         //이슈 메타 데이터 정보 임시 고정
         String metaContent = "---\nname: Issue template\nabout: Issue template\ntitle: ''\nlabels: ''\nassignees: ''\n---";
-        String content = metaContent + "\n" + createTemplateRequestDto.content();
-
-        String path = createTemplateRequestDto.type().equals("PR") ? PR_TEMPLATE_PATH : ISSUE_TEMPLATE_PATH;
+        String content = isPR ? createTemplateRequestDto.content() : metaContent + "\n" + createTemplateRequestDto.content();
+        String path = isPR ? PR_TEMPLATE_PATH : ISSUE_TEMPLATE_PATH;
 
         saveFileToGitHub(createTemplateRequestDto.repoUrl(), path, content, createTemplateRequestDto.type(), user.getGithubToken());
     }
@@ -128,6 +129,7 @@ public class TemplateService {
         }
     }
 
+    // 템플릿 리스트 조회
     public List<TemplateListResponseDto> getAllTemplate(TemplateType type) {
         List<Template> templates = templateRepository.findAllByType(type);
 

--- a/src/main/java/org/autorepo/server/domain/template/service/TemplateService.java
+++ b/src/main/java/org/autorepo/server/domain/template/service/TemplateService.java
@@ -1,7 +1,12 @@
 package org.autorepo.server.domain.template.service;
 
 import lombok.RequiredArgsConstructor;
+import org.autorepo.server.domain.repo.entity.Repo;
+import org.autorepo.server.domain.repo.repository.RepoRepository;
 import org.autorepo.server.domain.template.dto.request.CreateTemplateRequestDto;
+import org.autorepo.server.domain.template.entity.Template;
+import org.autorepo.server.domain.template.entity.TemplateType;
+import org.autorepo.server.domain.template.repository.TemplateRepository;
 import org.autorepo.server.domain.user.entity.User;
 import org.autorepo.server.domain.user.repository.UserRepository;
 import org.json.JSONObject;
@@ -18,6 +23,8 @@ public class TemplateService {
     private static final String ISSUE_TEMPLATE_PATH = ".github/ISSUE_TEMPLATE/issue_template.md";
 
     private final UserRepository userRepository;
+    private final TemplateRepository templateRepository;
+    private final RepoRepository repoRepository;
 
     // PR/ISSUE 템플릿 업로드
     public void uploadTemplate(CreateTemplateRequestDto createTemplateRequestDto) {
@@ -36,7 +43,7 @@ public class TemplateService {
 
 
     // GitHub API 요청
-    public void saveFileToGitHub(String repoUrl, String path, String content, String type, String token) {
+    private void saveFileToGitHub(String repoUrl, String path, String content, String type, String token) {
         RestTemplate restTemplate = new RestTemplate();
 
         String[] repoInfo = parseRepositoryUrl(repoUrl);
@@ -71,7 +78,7 @@ public class TemplateService {
     }
 
     // repo URL에서 owner와 repo 정보를 파싱
-    public String[] parseRepositoryUrl(String repoUrl) {
+    private String[] parseRepositoryUrl(String repoUrl) {
         String[] parts = repoUrl.split("/");
         if (parts.length < 5) {
             throw new IllegalArgumentException("잘못된 저장소 URL 형식입니다.");
@@ -93,6 +100,25 @@ public class TemplateService {
             return null;
         }
         return null;
+    }
+
+    // 템플릿 저장
+    public void saveTemplate(CreateTemplateRequestDto createTemplateRequestDto) {
+        Repo repo = repoRepository.findByRepoUrl(createTemplateRequestDto.repoUrl())
+                .orElseThrow(() -> new IllegalArgumentException("해당 Repo를 찾을 수 없습니다: " + createTemplateRequestDto.repoUrl()));
+
+        boolean templateExists = templateRepository.findByRepoAndContent(repo, createTemplateRequestDto.content())
+                .isPresent();
+
+        if (!templateExists) {
+            Template template = Template.builder()
+                    .content(createTemplateRequestDto.content())
+                    .type(TemplateType.valueOf(createTemplateRequestDto.type().toUpperCase()))
+                    .repo(repo)
+                    .build();
+
+            templateRepository.save(template);
+        }
     }
 
 }

--- a/src/main/java/org/autorepo/server/domain/template/service/TemplateService.java
+++ b/src/main/java/org/autorepo/server/domain/template/service/TemplateService.java
@@ -10,7 +10,10 @@ import org.autorepo.server.domain.template.repository.TemplateRepository;
 import org.autorepo.server.domain.user.entity.User;
 import org.autorepo.server.domain.user.repository.UserRepository;
 import org.json.JSONObject;
-import org.springframework.http.*;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
@@ -34,16 +37,16 @@ public class TemplateService {
 
         //이슈 메타 데이터 정보 임시 고정
         String metaContent = "---\nname: Issue template\nabout: Issue template\ntitle: ''\nlabels: ''\nassignees: ''\n---";
-        String content = metaContent  +"\n"+ createTemplateRequestDto.content();
+        String content = metaContent + "\n" + createTemplateRequestDto.content();
 
-        String path = createTemplateRequestDto.type().equalsIgnoreCase("PR") ? PR_TEMPLATE_PATH : ISSUE_TEMPLATE_PATH;
+        String path = createTemplateRequestDto.type().equals("PR") ? PR_TEMPLATE_PATH : ISSUE_TEMPLATE_PATH;
 
         saveFileToGitHub(createTemplateRequestDto.repoUrl(), path, content, createTemplateRequestDto.type(), user.getGithubToken());
     }
 
 
     // GitHub API 요청
-    private void saveFileToGitHub(String repoUrl, String path, String content, String type, String token) {
+    private void saveFileToGitHub(String repoUrl, String path, String content, TemplateType type, String token) {
         RestTemplate restTemplate = new RestTemplate();
 
         String[] repoInfo = parseRepositoryUrl(repoUrl);
@@ -113,12 +116,13 @@ public class TemplateService {
         if (!templateExists) {
             Template template = Template.builder()
                     .content(createTemplateRequestDto.content())
-                    .type(TemplateType.valueOf(createTemplateRequestDto.type().toUpperCase()))
+                    .type(createTemplateRequestDto.type())
                     .repo(repo)
                     .build();
 
             templateRepository.save(template);
         }
     }
+
 
 }

--- a/src/main/java/org/autorepo/server/domain/user/entity/User.java
+++ b/src/main/java/org/autorepo/server/domain/user/entity/User.java
@@ -20,6 +20,7 @@ public class User extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long userId;
     private String githubId;
+    private String githubToken;
     @Enumerated(EnumType.STRING)
     private UserRole userRole;
     @OneToMany(mappedBy = "user")

--- a/src/main/java/org/autorepo/server/global/common/SuccessCode.java
+++ b/src/main/java/org/autorepo/server/global/common/SuccessCode.java
@@ -1,0 +1,23 @@
+package org.autorepo.server.global.common;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum SuccessCode {
+    /**
+     * 200 Ok
+     */
+    OK(HttpStatus.OK, "요청이 성공했습니다."),
+
+    /**
+     * 201 Created
+     */
+    CREATED(HttpStatus.CREATED, "요청이 성공했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/org/autorepo/server/global/common/SuccessResponse.java
+++ b/src/main/java/org/autorepo/server/global/common/SuccessResponse.java
@@ -1,0 +1,37 @@
+package org.autorepo.server.global.common;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Getter
+public class SuccessResponse<T> {
+    private int status;
+    private String message;
+    private T data;
+
+    public static <T> ResponseEntity<SuccessResponse<?>> ok(T data) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessResponse.of(SuccessCode.OK, data));
+    }
+
+    public static <T> ResponseEntity<SuccessResponse<?>> created(T data) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(SuccessResponse.of(SuccessCode.CREATED, data));
+    }
+
+
+    public static <T> SuccessResponse<?> of(SuccessCode successCode, T data) {
+        return SuccessResponse.builder()
+                .status(successCode.getHttpStatus().value())
+                .message(successCode.getMessage())
+                .data(data)
+                .build();
+    }
+
+}

--- a/src/main/java/org/autorepo/server/global/config/SecurityConfig.java
+++ b/src/main/java/org/autorepo/server/global/config/SecurityConfig.java
@@ -16,6 +16,7 @@ public class SecurityConfig {
         http
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/api/template/**").permitAll() // 토큰 없이 임시 허용
                         .requestMatchers("/admin/**").hasRole("ADMIN")
                         .requestMatchers("/favicon.ico").permitAll()
                         .anyRequest().permitAll()


### PR DESCRIPTION
## 관련 이슈


- Resolves :: #9 

## 작업 사항
-  PR/ISSUE 템플릿 깃허브 업로드 API 구현
<img width="666" alt="스크린샷 2024-11-19 01 45 26" src="https://github.com/user-attachments/assets/2d61e920-b47e-4ba8-b0fd-1f8aed4faeb2">

-  PR/ISSUE 템플릿 공유(DB 저장) API 구현
![image](https://github.com/user-attachments/assets/c9c84e80-f865-4fcd-9898-660d4a872e53)


-  PR/ISSUE 템플릿 리스트 조회 API 구현 
<img width="668" alt="스크린샷 2024-11-19 01 45 13" src="https://github.com/user-attachments/assets/b5ba677b-1176-4374-a1eb-2c2a68ed1bac">



## 참고 사항

BE 전달사항
- 성공응답객체 하나 만들었습니다
- 유저 테이블에 깃허브 토큰(githubToken) 필드 추가했습니다. 템플릿 테이블에 템플릿 제목(title)필드 추가했습니다.
- 토큰 대신 임시로 userId로 받고있고 api/template 경로도 토큰없이 임시 허용해뒀는데 JWT 구현되면 수정 예정입니다.
- 커밋 메세지도 지정할 수 있어서 임의로 해뒀는데 나중에 리드미 업로드 구현하실 때 형식 통일하면 좋을 거 같아욤
- 깃허브 토큰 권한 어디까지 허용인지 추후 체크 필요합니다.


FE 전달사항
- 템플릿 content requestBody 보낼 때 줄바꿈은 /n으로 바꿔서 보내주셔야할 거 같슴다(json 형식이 줄바꿈 허용X라서)
- 이슈 템플릿은 PR템플릿과 다르게 마크다운 내용 위에(아래 이미지 참고) 메타 정보가 붙는데 이거는 일단 임의 Defult값으로 고정해뒀습니다.
![image](https://github.com/user-attachments/assets/8c48e89e-c23f-4675-85dc-689d785fe415)





