### PR TITLE
#11 [FEAT] 라벨 관련 API  & 대시보드 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     //json
     implementation 'org.json:json:20230227'
+    // http client
+    implementation 'org.apache.httpcomponents.client5:httpclient5:5.2.1'
+
 
 
 }

--- a/src/main/java/org/autorepo/server/domain/label/controller/LabelController.java
+++ b/src/main/java/org/autorepo/server/domain/label/controller/LabelController.java
@@ -1,12 +1,25 @@
 package org.autorepo.server.domain.label.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.autorepo.server.domain.label.dto.request.LabelListRequestDto;
+import org.autorepo.server.domain.label.dto.request.UploadLabalRequestDto;
+import org.autorepo.server.domain.label.service.LabelService;
+import org.autorepo.server.global.common.SuccessResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/label")
 @RestController
 public class LabelController {
+
+    private final LabelService labelService;
+
+    @PostMapping("/upload")
+    public ResponseEntity<SuccessResponse<?>> uploadLabels(
+            @RequestBody UploadLabalRequestDto uploadLabalRequestDto) {
+                labelService.uploadLabel(uploadLabalRequestDto);
+        return SuccessResponse.created(null);
+    }
 }
 

--- a/src/main/java/org/autorepo/server/domain/label/dto/request/LabelListRequestDto.java
+++ b/src/main/java/org/autorepo/server/domain/label/dto/request/LabelListRequestDto.java
@@ -1,0 +1,8 @@
+package org.autorepo.server.domain.label.dto.request;
+
+public record LabelListRequestDto(
+        String labelName,
+        String color,
+        String description
+) {
+}

--- a/src/main/java/org/autorepo/server/domain/label/dto/request/UploadLabalRequestDto.java
+++ b/src/main/java/org/autorepo/server/domain/label/dto/request/UploadLabalRequestDto.java
@@ -1,0 +1,10 @@
+package org.autorepo.server.domain.label.dto.request;
+
+import java.util.List;
+
+public record UploadLabalRequestDto(
+        Long userId,
+        String repoUrl,
+        List<LabelListRequestDto> labels
+) {
+}

--- a/src/main/java/org/autorepo/server/domain/label/dto/request/UploadLabalRequestDto.java
+++ b/src/main/java/org/autorepo/server/domain/label/dto/request/UploadLabalRequestDto.java
@@ -1,10 +1,13 @@
 package org.autorepo.server.domain.label.dto.request;
 
+import org.autorepo.server.domain.label.entity.LabelGenerateType;
+
 import java.util.List;
 
 public record UploadLabalRequestDto(
         Long userId,
         String repoUrl,
+        LabelGenerateType labelGenerateType,
         List<LabelListRequestDto> labels
 ) {
 }

--- a/src/main/java/org/autorepo/server/domain/label/entity/Label.java
+++ b/src/main/java/org/autorepo/server/domain/label/entity/Label.java
@@ -4,6 +4,10 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.autorepo.server.domain.repo.entity.Repo;
 
+@Setter
+@Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor
 @Table(name = "label")
 @Entity
@@ -12,6 +16,7 @@ public class Label {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long labelId;
+    private LabelGenerateType labelGenerateType;
     private String name;
     private String labelDescription;
     private String color;

--- a/src/main/java/org/autorepo/server/domain/label/entity/LabelGenerateType.java
+++ b/src/main/java/org/autorepo/server/domain/label/entity/LabelGenerateType.java
@@ -1,0 +1,8 @@
+package org.autorepo.server.domain.label.entity;
+
+public enum LabelGenerateType {
+    CSV,          // CSV로 생성
+    EMOJI,        // 이모지 라벨 생성
+    TEXT,         // 텍스트 라벨 생성
+    CUSTOM        // 처음 부터 생성
+}

--- a/src/main/java/org/autorepo/server/domain/label/repository/LabelRepository.java
+++ b/src/main/java/org/autorepo/server/domain/label/repository/LabelRepository.java
@@ -1,7 +1,11 @@
 package org.autorepo.server.domain.label.repository;
 
 import org.autorepo.server.domain.label.entity.Label;
+import org.autorepo.server.domain.label.entity.LabelGenerateType;
+import org.autorepo.server.domain.repo.entity.Repo;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LabelRepository extends JpaRepository<Label, Long> {
+
+    void deleteByLabelGenerateTypeAndRepo(LabelGenerateType labelGenerateType, Repo repo);
 }

--- a/src/main/java/org/autorepo/server/domain/label/service/LabelService.java
+++ b/src/main/java/org/autorepo/server/domain/label/service/LabelService.java
@@ -1,9 +1,14 @@
 package org.autorepo.server.domain.label.service;
 
 import lombok.RequiredArgsConstructor;
-import org.autorepo.server.domain.repo.service.GitHubService;
 import org.autorepo.server.domain.label.dto.request.LabelListRequestDto;
 import org.autorepo.server.domain.label.dto.request.UploadLabalRequestDto;
+import org.autorepo.server.domain.label.entity.Label;
+import org.autorepo.server.domain.label.entity.LabelGenerateType;
+import org.autorepo.server.domain.label.repository.LabelRepository;
+import org.autorepo.server.domain.repo.entity.Repo;
+import org.autorepo.server.domain.repo.repository.RepoRepository;
+import org.autorepo.server.domain.repo.service.GitHubService;
 import org.autorepo.server.domain.user.entity.User;
 import org.autorepo.server.domain.user.repository.UserRepository;
 import org.autorepo.server.global.error.ErrorCode;
@@ -22,6 +27,8 @@ public class LabelService {
 
     private final GitHubService gitHubService;
     private final UserRepository userRepository;
+    private final LabelRepository labelRepository;
+    private final RepoRepository repoRepository;
 
     public void uploadLabel(UploadLabalRequestDto uploadLabelRequestDto) {
         User user = userRepository.findById(uploadLabelRequestDto.userId())
@@ -30,17 +37,22 @@ public class LabelService {
         HttpHeaders headers = new HttpHeaders();
         String url = gitHubService.createGitHubApiUrl(GITHUB_LABEL_API, uploadLabelRequestDto.repoUrl(), null, headers, user.getGithubToken());
 
+        Repo repo = repoRepository.findByRepoUrl(uploadLabelRequestDto.repoUrl())
+                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.REPO_NOT_FOUND.getMessage()));
+
         try {
-            deleteAllLabels(url, headers);
-            for (LabelListRequestDto label : uploadLabelRequestDto.labels()) {
-                createLabel(url, headers, label);
+            deleteAllGitHubLabels(url, headers);
+            deleteAllDBLabels(uploadLabelRequestDto.labelGenerateType(), repo);
+
+            for (LabelListRequestDto labelDto : uploadLabelRequestDto.labels()) {
+                createAndSaveLabel(url, headers, labelDto, repo, uploadLabelRequestDto.labelGenerateType());
             }
         } catch (Exception e) {
             throw new RuntimeException(ErrorCode.GITHUB_LABEL_CREATE_ERROR.getMessage(), e);
         }
     }
 
-    private void deleteAllLabels(String url, HttpHeaders headers) {
+    private void deleteAllGitHubLabels(String url, HttpHeaders headers) {
         try {
             String responseBody = gitHubService.sendRequest(url, HttpMethod.GET, headers, null).getBody();
             if (responseBody == null || responseBody.trim().isEmpty()) return;
@@ -57,14 +69,32 @@ public class LabelService {
         }
     }
 
-    private void createLabel(String url, HttpHeaders headers, LabelListRequestDto label) {
+    private void deleteAllDBLabels(LabelGenerateType labelGenerateType, Repo repo) {
+        try {
+            labelRepository.deleteByLabelGenerateTypeAndRepo(labelGenerateType, repo);
+        } catch (Exception e) {
+            throw new RuntimeException(ErrorCode.LABEL_DELETE_ERROR.getMessage(), e);
+        }
+    }
+
+    private void createAndSaveLabel(String url, HttpHeaders headers, LabelListRequestDto labelDto, Repo repo, LabelGenerateType labelGenerateType) {
         JSONObject jsonBody = new JSONObject();
-        jsonBody.put("name", label.labelName());
-        jsonBody.put("color", label.color());
-        jsonBody.put("description", label.description());
+        jsonBody.put("name", labelDto.labelName());
+        jsonBody.put("color", labelDto.color());
+        jsonBody.put("description", labelDto.description());
 
         try {
             gitHubService.sendRequest(url, HttpMethod.POST, headers, jsonBody.toString());
+
+            Label newLabel = Label.builder()
+                    .name(labelDto.labelName())
+                    .color(labelDto.color())
+                    .labelDescription(labelDto.description())
+                    .labelGenerateType(labelGenerateType)
+                    .repo(repo)
+                    .build();
+            labelRepository.save(newLabel);
+
         } catch (Exception e) {
             throw new RuntimeException(ErrorCode.GITHUB_LABEL_CREATE_ERROR.getMessage(), e);
         }

--- a/src/main/java/org/autorepo/server/domain/label/service/LabelService.java
+++ b/src/main/java/org/autorepo/server/domain/label/service/LabelService.java
@@ -1,6 +1,16 @@
 package org.autorepo.server.domain.label.service;
 
 import lombok.RequiredArgsConstructor;
+import org.autorepo.server.domain.repo.service.GitHubService;
+import org.autorepo.server.domain.label.dto.request.LabelListRequestDto;
+import org.autorepo.server.domain.label.dto.request.UploadLabalRequestDto;
+import org.autorepo.server.domain.user.entity.User;
+import org.autorepo.server.domain.user.repository.UserRepository;
+import org.autorepo.server.global.error.ErrorCode;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -8,4 +18,55 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional
 public class LabelService {
+    private static final String GITHUB_LABEL_API = "https://api.github.com/repos/%s/%s/labels";
+
+    private final GitHubService gitHubService;
+    private final UserRepository userRepository;
+
+    public void uploadLabel(UploadLabalRequestDto uploadLabelRequestDto) {
+        User user = userRepository.findById(uploadLabelRequestDto.userId())
+                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.USER_NOT_FOUND.getMessage()));
+
+        HttpHeaders headers = new HttpHeaders();
+        String url = gitHubService.createGitHubApiUrl(GITHUB_LABEL_API, uploadLabelRequestDto.repoUrl(), null, headers, user.getGithubToken());
+
+        try {
+            deleteAllLabels(url, headers);
+            for (LabelListRequestDto label : uploadLabelRequestDto.labels()) {
+                createLabel(url, headers, label);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(ErrorCode.GITHUB_LABEL_CREATE_ERROR.getMessage(), e);
+        }
+    }
+
+    private void deleteAllLabels(String url, HttpHeaders headers) {
+        try {
+            String responseBody = gitHubService.sendRequest(url, HttpMethod.GET, headers, null).getBody();
+            if (responseBody == null || responseBody.trim().isEmpty()) return;
+
+            JSONArray existingLabels = new JSONArray(responseBody);
+            for (int i = 0; i < existingLabels.length(); i++) {
+                JSONObject label = existingLabels.getJSONObject(i);
+                String labelName = label.getString("name");
+                String deleteUrl = url + "/" + labelName;
+                gitHubService.sendRequest(deleteUrl, HttpMethod.DELETE, headers, null);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(ErrorCode.GITHUB_LABEL_DELETE_ERROR.getMessage(), e);
+        }
+    }
+
+    private void createLabel(String url, HttpHeaders headers, LabelListRequestDto label) {
+        JSONObject jsonBody = new JSONObject();
+        jsonBody.put("name", label.labelName());
+        jsonBody.put("color", label.color());
+        jsonBody.put("description", label.description());
+
+        try {
+            gitHubService.sendRequest(url, HttpMethod.POST, headers, jsonBody.toString());
+        } catch (Exception e) {
+            throw new RuntimeException(ErrorCode.GITHUB_LABEL_CREATE_ERROR.getMessage(), e);
+        }
+    }
 }

--- a/src/main/java/org/autorepo/server/domain/readme/entity/Readme.java
+++ b/src/main/java/org/autorepo/server/domain/readme/entity/Readme.java
@@ -3,11 +3,13 @@ package org.autorepo.server.domain.readme.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.autorepo.server.domain.repo.entity.Repo;
+import org.autorepo.server.global.common.BaseTimeEntity;
 
+@Getter
 @NoArgsConstructor
 @Table(name = "readme")
 @Entity
-public class Readme {
+public class Readme extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -18,7 +20,10 @@ public class Readme {
     @Column(columnDefinition = "TEXT")
     private String installation;
     private String stack;
+    private String content;
     @ManyToOne
     @JoinColumn(name = "repo_id")
     private Repo repo;
+
+
 }

--- a/src/main/java/org/autorepo/server/domain/readme/repository/ReadmeRepository.java
+++ b/src/main/java/org/autorepo/server/domain/readme/repository/ReadmeRepository.java
@@ -2,7 +2,11 @@ package org.autorepo.server.domain.readme.repository;
 
 import org.autorepo.server.domain.label.entity.Label;
 import org.autorepo.server.domain.readme.entity.Readme;
+import org.autorepo.server.domain.repo.entity.Repo;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ReadmeRepository extends JpaRepository<Readme, Long> {
+    List<Readme> findAllByRepoIn(List<Repo> userRepos);
 }

--- a/src/main/java/org/autorepo/server/domain/repo/entity/Repo.java
+++ b/src/main/java/org/autorepo/server/domain/repo/entity/Repo.java
@@ -9,6 +9,7 @@ import org.autorepo.server.domain.user.entity.User;
 
 import java.util.List;
 
+@Setter
 @NoArgsConstructor
 @Table(name = "repo")
 @Entity

--- a/src/main/java/org/autorepo/server/domain/repo/repository/RepoRepository.java
+++ b/src/main/java/org/autorepo/server/domain/repo/repository/RepoRepository.java
@@ -1,11 +1,14 @@
 package org.autorepo.server.domain.repo.repository;
 
-import org.autorepo.server.domain.label.entity.Label;
 import org.autorepo.server.domain.repo.entity.Repo;
+import org.autorepo.server.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface RepoRepository extends JpaRepository<Repo, Long> {
     Optional<Repo> findByRepoUrl(String repoUrl);
+
+    List<Repo> findAllByUser(User user);
 }

--- a/src/main/java/org/autorepo/server/domain/repo/service/GitHubService.java
+++ b/src/main/java/org/autorepo/server/domain/repo/service/GitHubService.java
@@ -1,0 +1,59 @@
+package org.autorepo.server.domain.repo.service;
+
+import lombok.RequiredArgsConstructor;
+import org.autorepo.server.global.error.ErrorCode;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.client.HttpClientErrorException;
+
+@RequiredArgsConstructor
+@Service
+public class GitHubService {
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    // 저장소 URL에서 owner와 repo 정보를 파싱
+    public String[] parseRepositoryUrl(String repoUrl) {
+        String[] parts = repoUrl.split("/");
+        if (parts.length < 5) {
+            throw new IllegalArgumentException(ErrorCode.BAD_REQUEST.getMessage());
+        }
+        String owner = parts[3];
+        String repo = parts[4].replace(".git", "");
+        return new String[]{owner, repo};
+    }
+
+    // GitHub API URL 생성
+    public String createGitHubApiUrl(String apiTemplate, String repoUrl, String path, HttpHeaders headers, String token) {
+        String[] repoInfo = parseRepositoryUrl(repoUrl);
+        headers.set("Authorization", "Bearer " + token);
+        headers.set("Content-Type", "application/json");
+        return String.format(apiTemplate, repoInfo[0], repoInfo[1], path != null ? path : "");
+    }
+
+    // GitHub API 요청
+    public ResponseEntity<String> sendRequest(String url, HttpMethod method, HttpHeaders headers, String body) {
+        HttpEntity<String> request = new HttpEntity<>(body, headers);
+        try {
+            return restTemplate.exchange(url, method, request, String.class);
+        } catch (HttpClientErrorException e) {
+            throw new RuntimeException(ErrorCode.GITHUB_API_ERROR.getMessage() + ": " + e.getMessage(), e);
+        }
+    }
+
+    // GitHub API로 SHA 조회(기존 값 존재 유무 확인)
+    public String getFileSha(String url, HttpHeaders headers) {
+        try {
+            ResponseEntity<String> response = sendRequest(url, HttpMethod.GET, headers, null);
+            if (response.getStatusCode().is2xxSuccessful()) {
+                return new org.json.JSONObject(response.getBody()).getString("sha");
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(ErrorCode.UNPROCESSABLE_ENTITY.getMessage(), e);
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/autorepo/server/domain/template/controller/TemplateController.java
+++ b/src/main/java/org/autorepo/server/domain/template/controller/TemplateController.java
@@ -2,8 +2,9 @@ package org.autorepo.server.domain.template.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.autorepo.server.domain.template.dto.request.ShareTemplateRequestDto;
-import org.autorepo.server.domain.template.dto.response.TemplateListResponseDto;
 import org.autorepo.server.domain.template.dto.request.UploadTemplateRequestDto;
+import org.autorepo.server.domain.template.dto.response.DashboardTemplateResponseDto;
+import org.autorepo.server.domain.template.dto.response.TemplateListResponseDto;
 import org.autorepo.server.domain.template.entity.TemplateType;
 import org.autorepo.server.domain.template.service.TemplateService;
 import org.autorepo.server.global.common.SuccessResponse;
@@ -37,4 +38,11 @@ public class TemplateController {
         List<TemplateListResponseDto> templateListResponseDto = templateService.getAllTemplate(type);
         return SuccessResponse.ok(templateListResponseDto);
     }
+
+    @GetMapping("/dash-board")
+    public ResponseEntity<SuccessResponse<?>> getDashBoard(@RequestParam Long userId) {
+        DashboardTemplateResponseDto dashboardTemplateResponseDto = templateService.getDashBoardTemplates(userId);
+        return SuccessResponse.ok(dashboardTemplateResponseDto);
+    }
+
 }

--- a/src/main/java/org/autorepo/server/domain/template/controller/TemplateController.java
+++ b/src/main/java/org/autorepo/server/domain/template/controller/TemplateController.java
@@ -2,7 +2,7 @@ package org.autorepo.server.domain.template.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.autorepo.server.domain.template.dto.request.ShareTemplateRequestDto;
-import org.autorepo.server.domain.template.dto.request.TemplateListResponseDto;
+import org.autorepo.server.domain.template.dto.response.TemplateListResponseDto;
 import org.autorepo.server.domain.template.dto.request.UploadTemplateRequestDto;
 import org.autorepo.server.domain.template.entity.TemplateType;
 import org.autorepo.server.domain.template.service.TemplateService;

--- a/src/main/java/org/autorepo/server/domain/template/dto/request/ShareTemplateRequestDto.java
+++ b/src/main/java/org/autorepo/server/domain/template/dto/request/ShareTemplateRequestDto.java
@@ -4,6 +4,7 @@ import org.autorepo.server.domain.template.entity.TemplateType;
 
 public record ShareTemplateRequestDto(
         Long userId,
+        String repoUrl,
         TemplateType type,
         String title,
         String content

--- a/src/main/java/org/autorepo/server/domain/template/dto/response/DashboardTemplateResponseDto.java
+++ b/src/main/java/org/autorepo/server/domain/template/dto/response/DashboardTemplateResponseDto.java
@@ -1,0 +1,9 @@
+package org.autorepo.server.domain.template.dto.response;
+
+import java.util.List;
+
+public record DashboardTemplateResponseDto(
+        List<RandomTemplateResponseDto> randomTemplates,
+        List<RecentTemplateResponseDto> recentTemplates
+) {
+}

--- a/src/main/java/org/autorepo/server/domain/template/dto/response/RandomTemplateResponseDto.java
+++ b/src/main/java/org/autorepo/server/domain/template/dto/response/RandomTemplateResponseDto.java
@@ -1,0 +1,8 @@
+package org.autorepo.server.domain.template.dto.response;
+
+public record RandomTemplateResponseDto(
+        String type,
+        String title,
+        String content
+) {
+}

--- a/src/main/java/org/autorepo/server/domain/template/dto/response/RecentTemplateResponseDto.java
+++ b/src/main/java/org/autorepo/server/domain/template/dto/response/RecentTemplateResponseDto.java
@@ -1,0 +1,12 @@
+package org.autorepo.server.domain.template.dto.response;
+
+import java.time.LocalDateTime;
+
+public record RecentTemplateResponseDto(
+        LocalDateTime modifiedAt,
+        String type,
+        String title,
+        String content
+) {
+
+}

--- a/src/main/java/org/autorepo/server/domain/template/dto/response/TemplateListResponseDto.java
+++ b/src/main/java/org/autorepo/server/domain/template/dto/response/TemplateListResponseDto.java
@@ -1,4 +1,4 @@
-package org.autorepo.server.domain.template.dto.request;
+package org.autorepo.server.domain.template.dto.response;
 
 import org.autorepo.server.domain.template.entity.Template;
 

--- a/src/main/java/org/autorepo/server/domain/template/dto/response/TemplateListResponseDto.java
+++ b/src/main/java/org/autorepo/server/domain/template/dto/response/TemplateListResponseDto.java
@@ -4,11 +4,13 @@ import org.autorepo.server.domain.template.entity.Template;
 
 public record TemplateListResponseDto(
         Long templateId,
+        String title,
         String content
 ) {
     public static TemplateListResponseDto of(Template template) {
         return new TemplateListResponseDto(
                 template.getTemplateId(),
+                template.getTitle(),
                 template.getContent()
         );
     }

--- a/src/main/java/org/autorepo/server/domain/template/entity/Template.java
+++ b/src/main/java/org/autorepo/server/domain/template/entity/Template.java
@@ -3,6 +3,7 @@ package org.autorepo.server.domain.template.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.autorepo.server.domain.repo.entity.Repo;
+import org.autorepo.server.global.common.BaseTimeEntity;
 
 @Getter
 @AllArgsConstructor
@@ -10,7 +11,7 @@ import org.autorepo.server.domain.repo.entity.Repo;
 @NoArgsConstructor
 @Table(name = "template")
 @Entity
-public class Template {
+public class Template extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,4 +25,8 @@ public class Template {
     @JoinColumn(name = "repo_id")
     private Repo repo;
 
+    public void updateContent(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
 }

--- a/src/main/java/org/autorepo/server/domain/template/repository/TemplateRepository.java
+++ b/src/main/java/org/autorepo/server/domain/template/repository/TemplateRepository.java
@@ -9,7 +9,9 @@ import java.util.List;
 import java.util.Optional;
 
 public interface TemplateRepository extends JpaRepository<Template, Long> {
-    Optional<Template> findByTitleAndContent(String title, String content);
+    Optional<Template> findByRepoAndType(Repo repo, TemplateType type);
 
     List<Template> findAllByType(TemplateType type);
+
+    List<Template> findAllByRepoIn(List<Repo> userRepos);
 }

--- a/src/main/java/org/autorepo/server/domain/template/service/TemplateService.java
+++ b/src/main/java/org/autorepo/server/domain/template/service/TemplateService.java
@@ -1,23 +1,20 @@
 package org.autorepo.server.domain.template.service;
 
 import lombok.RequiredArgsConstructor;
-import org.autorepo.server.domain.repo.entity.Repo;
-import org.autorepo.server.domain.repo.repository.RepoRepository;
+import org.autorepo.server.domain.repo.service.GitHubService;
 import org.autorepo.server.domain.template.dto.request.ShareTemplateRequestDto;
-import org.autorepo.server.domain.template.dto.request.TemplateListResponseDto;
 import org.autorepo.server.domain.template.dto.request.UploadTemplateRequestDto;
+import org.autorepo.server.domain.template.dto.response.TemplateListResponseDto;
 import org.autorepo.server.domain.template.entity.Template;
 import org.autorepo.server.domain.template.entity.TemplateType;
 import org.autorepo.server.domain.template.repository.TemplateRepository;
 import org.autorepo.server.domain.user.entity.User;
 import org.autorepo.server.domain.user.repository.UserRepository;
+import org.autorepo.server.global.error.ErrorCode;
 import org.json.JSONObject;
-import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -27,93 +24,43 @@ import java.util.stream.Collectors;
 public class TemplateService {
 
     private static final String GITHUB_API_URL = "https://api.github.com/repos/%s/%s/contents/%s";
-    private static final String PR_TEMPLATE_PATH = ".github/pull_request_template.md";
-    private static final String ISSUE_TEMPLATE_PATH = ".github/ISSUE_TEMPLATE/issue_template.md";
 
+    private final GitHubService gitHubService;
     private final UserRepository userRepository;
     private final TemplateRepository templateRepository;
-    private final RepoRepository repoRepository;
 
-    // PR/ISSUE 템플릿 업로드
+    // 템플릿 업로드
     public void uploadTemplate(UploadTemplateRequestDto uploadTemplateRequestDto) {
-
         User user = userRepository.findById(uploadTemplateRequestDto.userId())
-                .orElseThrow(() -> new IllegalArgumentException("해당 ID를 가진 사용자를 찾을 수 없습니다: " + uploadTemplateRequestDto.userId()));
+                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.USER_NOT_FOUND.getMessage()));
 
+        // PR/ISSUE 템플릿 구분
         boolean isPR = uploadTemplateRequestDto.type() == TemplateType.PR;
-
-        //이슈 메타 데이터 정보 임시 고정
         String metaContent = "---\nname: Issue template\nabout: Issue template\ntitle: ''\nlabels: ''\nassignees: ''\n---";
         String content = isPR ? uploadTemplateRequestDto.content() : metaContent + "\n" + uploadTemplateRequestDto.content();
-        String path = isPR ? PR_TEMPLATE_PATH : ISSUE_TEMPLATE_PATH;
-
-        saveFileToGitHub(uploadTemplateRequestDto.repoUrl(), path, content, uploadTemplateRequestDto.type(), user.getGithubToken());
-    }
-
-
-    // GitHub API 요청
-    private void saveFileToGitHub(String repoUrl, String path, String content, TemplateType type, String token) {
-        RestTemplate restTemplate = new RestTemplate();
-
-        String[] repoInfo = parseRepositoryUrl(repoUrl);
-        String owner = repoInfo[0];
-        String repo = repoInfo[1];
-        String url = String.format(GITHUB_API_URL, owner, repo, path);
+        String path = isPR ? ".github/pull_request_template.md" : ".github/ISSUE_TEMPLATE/issue_template.md";
 
         HttpHeaders headers = new HttpHeaders();
-        headers.set("Authorization", "Bearer " + token);
-        headers.set("Content-Type", "application/json");
-
-        String sha = getFileShaIfExists(restTemplate, url, headers);
+        String url = gitHubService.createGitHubApiUrl(GITHUB_API_URL, uploadTemplateRequestDto.repoUrl(), path, headers, user.getGithubToken());
         String base64Content = java.util.Base64.getEncoder().encodeToString(content.getBytes());
-
         JSONObject jsonBody = new JSONObject();
-        jsonBody.put("message", "Update " + type + " Template");
+        jsonBody.put("message", "Update " + uploadTemplateRequestDto.type() + " Template");
         jsonBody.put("content", base64Content);
-        if (sha != null) {
-            jsonBody.put("sha", sha);
-        }
 
-        HttpEntity<String> request = new HttpEntity<>(jsonBody.toString(), headers);
-
+        //기존 템플릿 존재 여부 확인
         try {
-            ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.PUT, request, String.class);
-            if (!response.getStatusCode().is2xxSuccessful()) {
-                throw new RuntimeException("파일 저장 실패: " + response.getBody());
+            String sha = gitHubService.getFileSha(url, headers);
+            if (sha != null) {
+                jsonBody.put("sha", sha);
             }
+            gitHubService.sendRequest(url, HttpMethod.PUT, headers, jsonBody.toString());
         } catch (Exception e) {
-            throw new RuntimeException("파일 저장 중 오류 발생: " + e.getMessage(), e);
+            throw new RuntimeException(ErrorCode.GITHUB_TEMPLATE_UPLOAD_ERROR.getMessage(), e);
         }
-    }
-
-    // repo URL에서 owner와 repo 정보를 파싱
-    private String[] parseRepositoryUrl(String repoUrl) {
-        String[] parts = repoUrl.split("/");
-        if (parts.length < 5) {
-            throw new IllegalArgumentException("잘못된 저장소 URL 형식입니다.");
-        }
-        String owner = parts[3];
-        String repo = parts[4].replace(".git", "");
-        return new String[]{owner, repo};
-    }
-
-    // GitHub 저장소에서 SHA값 조회(이전 파일이 존재하는지 확인)
-    private String getFileShaIfExists(RestTemplate restTemplate, String url, HttpHeaders headers) {
-        try {
-            HttpEntity<Void> request = new HttpEntity<>(headers);
-            ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, request, String.class);
-            if (response.getStatusCode().is2xxSuccessful()) {
-                return new JSONObject(response.getBody()).getString("sha");
-            }
-        } catch (Exception ignored) {
-            return null;
-        }
-        return null;
     }
 
     // 템플릿 저장
     public void saveTemplate(ShareTemplateRequestDto shareTemplateRequestDto) {
-
         boolean templateExists = templateRepository.findByTitleAndContent(shareTemplateRequestDto.title(), shareTemplateRequestDto.content())
                 .isPresent();
 
@@ -128,14 +75,10 @@ public class TemplateService {
         }
     }
 
-    // 템플릿 리스트 조회
+    // 템플릿 조회
     public List<TemplateListResponseDto> getAllTemplate(TemplateType type) {
-        List<Template> templates = templateRepository.findAllByType(type);
-
-        return templates.stream()
+        return templateRepository.findAllByType(type).stream()
                 .map(TemplateListResponseDto::of)
                 .collect(Collectors.toList());
     }
-
-
 }

--- a/src/main/java/org/autorepo/server/domain/template/service/TemplateService.java
+++ b/src/main/java/org/autorepo/server/domain/template/service/TemplateService.java
@@ -1,6 +1,8 @@
 package org.autorepo.server.domain.template.service;
 
 import lombok.RequiredArgsConstructor;
+import org.autorepo.server.domain.repo.entity.Repo;
+import org.autorepo.server.domain.repo.repository.RepoRepository;
 import org.autorepo.server.domain.repo.service.GitHubService;
 import org.autorepo.server.domain.template.dto.request.ShareTemplateRequestDto;
 import org.autorepo.server.domain.template.dto.request.UploadTemplateRequestDto;
@@ -28,6 +30,7 @@ public class TemplateService {
     private final GitHubService gitHubService;
     private final UserRepository userRepository;
     private final TemplateRepository templateRepository;
+    private final RepoRepository repoRepository;
 
     // 템플릿 업로드
     public void uploadTemplate(UploadTemplateRequestDto uploadTemplateRequestDto) {
@@ -61,11 +64,18 @@ public class TemplateService {
 
     // 템플릿 저장
     public void saveTemplate(ShareTemplateRequestDto shareTemplateRequestDto) {
-        boolean templateExists = templateRepository.findByTitleAndContent(shareTemplateRequestDto.title(), shareTemplateRequestDto.content())
-                .isPresent();
+        Repo repo = repoRepository.findByRepoUrl(shareTemplateRequestDto.repoUrl())
+                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.REPO_NOT_FOUND.getMessage()));
+
+        boolean templateExists = templateRepository.findByRepoAndTitleAndContent(
+                repo,
+                shareTemplateRequestDto.title(),
+                shareTemplateRequestDto.content()
+        ).isPresent();
 
         if (!templateExists) {
             Template template = Template.builder()
+                    .repo(repo)
                     .title(shareTemplateRequestDto.title())
                     .content(shareTemplateRequestDto.content())
                     .type(shareTemplateRequestDto.type())

--- a/src/main/java/org/autorepo/server/domain/template/service/TemplateService.java
+++ b/src/main/java/org/autorepo/server/domain/template/service/TemplateService.java
@@ -1,11 +1,16 @@
 package org.autorepo.server.domain.template.service;
 
 import lombok.RequiredArgsConstructor;
+import org.autorepo.server.domain.readme.entity.Readme;
+import org.autorepo.server.domain.readme.repository.ReadmeRepository;
 import org.autorepo.server.domain.repo.entity.Repo;
 import org.autorepo.server.domain.repo.repository.RepoRepository;
 import org.autorepo.server.domain.repo.service.GitHubService;
 import org.autorepo.server.domain.template.dto.request.ShareTemplateRequestDto;
 import org.autorepo.server.domain.template.dto.request.UploadTemplateRequestDto;
+import org.autorepo.server.domain.template.dto.response.DashboardTemplateResponseDto;
+import org.autorepo.server.domain.template.dto.response.RandomTemplateResponseDto;
+import org.autorepo.server.domain.template.dto.response.RecentTemplateResponseDto;
 import org.autorepo.server.domain.template.dto.response.TemplateListResponseDto;
 import org.autorepo.server.domain.template.entity.Template;
 import org.autorepo.server.domain.template.entity.TemplateType;
@@ -18,7 +23,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
@@ -31,6 +36,7 @@ public class TemplateService {
     private final UserRepository userRepository;
     private final TemplateRepository templateRepository;
     private final RepoRepository repoRepository;
+    private final ReadmeRepository readmeRepository;
 
     // 템플릿 업로드
     public void uploadTemplate(UploadTemplateRequestDto uploadTemplateRequestDto) {
@@ -64,26 +70,29 @@ public class TemplateService {
 
     // 템플릿 저장
     public void saveTemplate(ShareTemplateRequestDto shareTemplateRequestDto) {
+
         Repo repo = repoRepository.findByRepoUrl(shareTemplateRequestDto.repoUrl())
                 .orElseThrow(() -> new IllegalArgumentException(ErrorCode.REPO_NOT_FOUND.getMessage()));
 
-        boolean templateExists = templateRepository.findByRepoAndTitleAndContent(
-                repo,
-                shareTemplateRequestDto.title(),
-                shareTemplateRequestDto.content()
-        ).isPresent();
+        Template existingTemplate = templateRepository.findByRepoAndType(repo, shareTemplateRequestDto.type())
+                .orElse(null);
 
-        if (!templateExists) {
-            Template template = Template.builder()
+        if (existingTemplate != null) {
+            existingTemplate.updateContent(shareTemplateRequestDto.title(), shareTemplateRequestDto.content());
+            templateRepository.save(existingTemplate);
+        } else {
+            // 새로운 템플릿 생성
+            Template newTemplate = Template.builder()
                     .repo(repo)
                     .title(shareTemplateRequestDto.title())
                     .content(shareTemplateRequestDto.content())
                     .type(shareTemplateRequestDto.type())
                     .build();
 
-            templateRepository.save(template);
+            templateRepository.save(newTemplate);
         }
     }
+
 
     // 템플릿 조회
     public List<TemplateListResponseDto> getAllTemplate(TemplateType type) {
@@ -91,4 +100,66 @@ public class TemplateService {
                 .map(TemplateListResponseDto::of)
                 .collect(Collectors.toList());
     }
+
+    // 대시보드 템플릿 조회
+    public DashboardTemplateResponseDto getDashBoardTemplates(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.USER_NOT_FOUND.getMessage()));
+
+        // 전체 템플릿 리드미
+        List<Template> allTemplates = templateRepository.findAll();
+        List<Readme> allReadmes = readmeRepository.findAll();
+
+        // 내 템플릿, 리드미
+        List<Repo> userRepos = repoRepository.findAllByUser(user);
+        List<Template> myTemplates = templateRepository.findAllByRepoIn(userRepos);
+        List<Readme> myReadmes = readmeRepository.findAllByRepoIn(userRepos);
+
+        // 랜덤 템플릿
+        List<RandomTemplateResponseDto> randomTemplates = combineTemplatesAndReadmes(allTemplates, allReadmes).stream()
+                .sorted((o1, o2) -> new Random().nextInt(3) - 1)
+                .limit(5)
+                .map(template -> new RandomTemplateResponseDto(
+                        template.type(),
+                        template.title(),
+                        template.content()
+                ))
+                .toList();
+
+        // 최근 템플릿
+        List<RecentTemplateResponseDto> recentTemplates = combineTemplatesAndReadmes(myTemplates, myReadmes).stream()
+                .sorted(Comparator.comparing(RecentTemplateResponseDto::modifiedAt).reversed())
+                .limit(5)
+                .map(template -> new RecentTemplateResponseDto(
+                        template.modifiedAt(),
+                        template.type(),
+                        template.title(),
+                        template.content()
+                ))
+                .toList();
+
+        return new DashboardTemplateResponseDto(randomTemplates, recentTemplates);
+    }
+
+    //템플릿, 리드미 합치기
+    private List<RecentTemplateResponseDto> combineTemplatesAndReadmes(List<Template> templates, List<Readme> readmes) {
+        List<RecentTemplateResponseDto> result = new ArrayList<>();
+
+        templates.forEach(template -> result.add(new RecentTemplateResponseDto(
+                template.getModifiedAt(),
+                template.getType().name(),
+                template.getTitle(),
+                template.getContent()
+        )));
+
+        readmes.forEach(readme -> result.add(new RecentTemplateResponseDto(
+                readme.getModifiedAt(),
+                "README",
+                readme.getTitle(),
+                readme.getContent()
+        )));
+
+        return result;
+    }
+
 }

--- a/src/main/java/org/autorepo/server/global/error/ErrorCode.java
+++ b/src/main/java/org/autorepo/server/global/error/ErrorCode.java
@@ -26,7 +26,8 @@ public enum ErrorCode {
     /**
      * 404 Not Found
      */
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 멤버를 찾을 수 없습니다."),
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 멤버를 찾을 수 없습니다."),
 
     /**
      * 405 Method Not Allowed
@@ -39,9 +40,18 @@ public enum ErrorCode {
     CONFLICT(HttpStatus.CONFLICT, "이미 존재하는 리소스입니다."),
 
     /**
+     * 422 Unprocessable Entity
+     */
+    UNPROCESSABLE_ENTITY(HttpStatus.UNPROCESSABLE_ENTITY, "요청 처리에 실패했습니다."),
+
+    /**
      * 500 Internal Server Error
      */
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다.");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
+    GITHUB_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "GitHub API 호출 중 오류가 발생했습니다."),
+    GITHUB_LABEL_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "기존 라벨 삭제 중 오류가 발생했습니다."),
+    GITHUB_LABEL_CREATE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "라벨 생성 중 오류가 발생했습니다."),
+    GITHUB_TEMPLATE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "템플릿 업로드 중 오류가 발생했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/org/autorepo/server/global/error/ErrorCode.java
+++ b/src/main/java/org/autorepo/server/global/error/ErrorCode.java
@@ -49,9 +49,10 @@ public enum ErrorCode {
      */
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
     GITHUB_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "GitHub API 호출 중 오류가 발생했습니다."),
-    GITHUB_LABEL_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "기존 라벨 삭제 중 오류가 발생했습니다."),
-    GITHUB_LABEL_CREATE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "라벨 생성 중 오류가 발생했습니다."),
-    GITHUB_TEMPLATE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "템플릿 업로드 중 오류가 발생했습니다.");
+    GITHUB_LABEL_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "깃허브 기존 라벨 삭제 중 오류가 발생했습니다."),
+    GITHUB_LABEL_CREATE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "깃허브 라벨 생성 중 오류가 발생했습니다."),
+    GITHUB_TEMPLATE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "깃허브 템플릿 업로드 중 오류가 발생했습니다."),
+    LABEL_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "라벨 삭제 중 오류가 발생했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/org/autorepo/server/global/error/ErrorCode.java
+++ b/src/main/java/org/autorepo/server/global/error/ErrorCode.java
@@ -28,7 +28,7 @@ public enum ErrorCode {
      */
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 멤버를 찾을 수 없습니다."),
-
+    REPO_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 레포지토리를 찾을 수 없습니다."),
     /**
      * 405 Method Not Allowed
      */


### PR DESCRIPTION
## 관련 이슈
- Resolves : #11 

## 작업 사항

- 라벨 업로드 API 구현
<img width="996" alt="스크린샷 2024-11-24 21 07 24" src="https://github.com/user-attachments/assets/5012d2cd-8f79-4da5-b3cc-95417fede4c3">

 - 대시보드 조회 (랜덤, 최근 템플릿, 리드미 리스트 조회 ) API 구현
<img width="1016" alt="스크린샷 2024-11-24 21 07 36" src="https://github.com/user-attachments/assets/7083596e-efa5-4f36-83a2-16e5d61ccb4f">



## 참고 사항

BE 전달사항
- 라벨 업로드, 템플릿 업로드 구현하면서 겹치는 Github api 관련 코드가 많아서 GithubService 클래스 새로 만들어서 옮겨놨습니다.(readme 업로드 할 때 사용 가능할 거 같은..?)
- 리드미 마크다운 완성본 내용 저장하는 필드가 없어서 content 필드 추가해뒀는데 나중에 AI 생성이나 리드미 API 구현 방식에 따라 수정할 거 같긴합니다!)
- 최근 수정한 템플릿 정보 필요해서 readme와 template엔티티에 basetimeentity 상속했습니다 (생성 일자, 수정 일자 필드 추가)
- 토큰은 추후 적용 예정

FE 전달사항
- 라벨 DB에 저장 언제 저장할 지(따로 API 만들지?) 논의 필요
- 대시보드 조회는 리드미, PR, ISSUE 템플릿(라벨 제외) 중  랜덤으로 5개 가져온 템플릿과  최근 수정한 내 템플릿(modifiedAt기준) 5개를 리턴하는 API 입니다. (리턴 개수나 방식 일부 논의 필요)
