### PR TITLE
[FEAT] 대시보드 조회 뷰 / 대시보드 디테일 뷰 분리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,15 +55,13 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	//WenClient
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
-    //CommonMark
-    implementation 'org.commonmark:commonmark:0.18.1'
-    // JavaFX
-    implementation "org.openjfx:javafx-controls:17.0.2"
-    implementation "org.openjfx:javafx-graphics:17.0.2:mac"
-    implementation "org.openjfx:javafx-swing:17.0.2"
     //aws
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.541'
-
+    // Flying Saucer
+    implementation 'org.xhtmlrenderer:flying-saucer-core:9.1.22'
+    implementation 'org.xhtmlrenderer:flying-saucer-pdf:9.1.22'
+    // Flexmark
+    implementation 'com.vladsch.flexmark:flexmark-all:0.64.0'
 
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -37,16 +37,16 @@ dependencies {
 	//Multipart file
 	implementation("software.amazon.awssdk:bom:2.21.0")
 	implementation("software.amazon.awssdk:s3:2.21.0")
-  //jpa
-  implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    //jpa
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	// Spring Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	// Spring OAuth2 Client
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-  //json
-  implementation 'org.json:json:20230227'
-  // http client
-  implementation 'org.apache.httpcomponents.client5:httpclient5:5.2.1'
+    //json
+    implementation 'org.json:json:20230227'
+    // http client
+    implementation 'org.apache.httpcomponents.client5:httpclient5:5.2.1'
 	//JWT
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
@@ -55,6 +55,20 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	//WenClient
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    //CommonMark
+    implementation 'org.commonmark:commonmark:0.18.1'
+    // JavaFX
+    implementation "org.openjfx:javafx-controls:17.0.2"
+    implementation "org.openjfx:javafx-graphics:17.0.2:mac"
+    implementation "org.openjfx:javafx-swing:17.0.2"
+    //aws
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.541'
+
+
+
+
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/org/autorepo/server/domain/label/service/LabelService.java
+++ b/src/main/java/org/autorepo/server/domain/label/service/LabelService.java
@@ -7,6 +7,8 @@ import org.autorepo.server.domain.label.dto.request.UploadLabalRequestDto;
 import org.autorepo.server.domain.user.entity.User;
 import org.autorepo.server.domain.user.repository.UserRepository;
 import org.autorepo.server.global.error.ErrorCode;
+import org.autorepo.server.global.error.exception.EntityNotFoundException;
+import org.autorepo.server.global.error.exception.InternalServerException;
 import org.autorepo.server.global.utils.GitHubService;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -14,6 +16,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static org.autorepo.server.global.error.ErrorCode.*;
 
 @RequiredArgsConstructor
 @Service
@@ -26,7 +30,7 @@ public class LabelService {
 
     public void uploadLabel(UploadLabalRequestDto uploadLabelRequestDto, Long userId) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.USER_NOT_FOUND.getMessage()));
+                .orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));
 
         HttpHeaders headers = new HttpHeaders();
         String url = gitHubService.createGitHubApiUrl(GITHUB_LABEL_API, uploadLabelRequestDto.repoUrl(), null, headers, user.getGithubToken());
@@ -37,7 +41,7 @@ public class LabelService {
                 createLabel(url, headers, label);
             }
         } catch (Exception e) {
-            throw new RuntimeException(ErrorCode.GITHUB_LABEL_CREATE_ERROR.getMessage(), e);
+            throw new InternalServerException(GITHUB_LABEL_CREATE_ERROR);
         }
     }
 
@@ -54,7 +58,7 @@ public class LabelService {
                 gitHubService.sendRequest(deleteUrl, HttpMethod.DELETE, headers, null);
             }
         } catch (Exception e) {
-            throw new RuntimeException(ErrorCode.GITHUB_LABEL_DELETE_ERROR.getMessage(), e);
+            throw new InternalServerException(GITHUB_LABEL_DELETE_ERROR);
         }
     }
 
@@ -67,7 +71,7 @@ public class LabelService {
         try {
             gitHubService.sendRequest(url, HttpMethod.POST, headers, jsonBody.toString());
         } catch (Exception e) {
-            throw new RuntimeException(ErrorCode.GITHUB_LABEL_CREATE_ERROR.getMessage(), e);
+            throw new InternalServerException(GITHUB_LABEL_CREATE_ERROR);
         }
     }
 

--- a/src/main/java/org/autorepo/server/domain/label/service/LabelService.java
+++ b/src/main/java/org/autorepo/server/domain/label/service/LabelService.java
@@ -3,15 +3,11 @@ package org.autorepo.server.domain.label.service;
 import lombok.RequiredArgsConstructor;
 import org.autorepo.server.domain.label.dto.request.LabelListRequestDto;
 import org.autorepo.server.domain.label.dto.request.UploadLabalRequestDto;
-import org.autorepo.server.domain.label.entity.Label;
-import org.autorepo.server.domain.label.entity.LabelGenerateType;
-import org.autorepo.server.domain.label.repository.LabelRepository;
-import org.autorepo.server.domain.repo.entity.Repo;
-import org.autorepo.server.domain.repo.repository.RepoRepository;
-import org.autorepo.server.domain.repo.service.GitHubService;
+
 import org.autorepo.server.domain.user.entity.User;
 import org.autorepo.server.domain.user.repository.UserRepository;
 import org.autorepo.server.global.error.ErrorCode;
+import org.autorepo.server.global.utils.GitHubService;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.springframework.http.HttpHeaders;

--- a/src/main/java/org/autorepo/server/domain/readme/entity/Readme.java
+++ b/src/main/java/org/autorepo/server/domain/readme/entity/Readme.java
@@ -22,6 +22,7 @@ public class Readme extends BaseTimeEntity {
     private String stack;
     @Column(columnDefinition = "TEXT")
     private String content;
+    private String imageUrl;
     @ManyToOne
     @JoinColumn(name = "repo_id")
     private Repo repo;

--- a/src/main/java/org/autorepo/server/domain/template/controller/TemplateController.java
+++ b/src/main/java/org/autorepo/server/domain/template/controller/TemplateController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.autorepo.server.domain.template.dto.request.ShareTemplateRequestDto;
 import org.autorepo.server.domain.template.dto.request.UploadTemplateRequestDto;
 import org.autorepo.server.domain.template.dto.response.DashboardTemplateResponseDto;
+import org.autorepo.server.domain.template.dto.response.TemplateInfoResponseDto;
 import org.autorepo.server.domain.template.dto.response.TemplateListResponseDto;
 import org.autorepo.server.domain.template.entity.TemplateType;
 import org.autorepo.server.domain.template.service.TemplateService;
@@ -49,5 +50,12 @@ public class TemplateController {
         DashboardTemplateResponseDto dashboardTemplateResponseDto = templateService.getDashBoardTemplates(userId);
         return SuccessResponse.ok(dashboardTemplateResponseDto);
     }
+
+    @GetMapping("/{type}/{templateId}")
+    public ResponseEntity<SuccessResponse<?>> getTemplateInfo(@PathVariable Long templateId, @PathVariable String type) {
+        TemplateInfoResponseDto templateInfoResponseDto = templateService.getTemplateInfo(templateId,type);
+        return SuccessResponse.ok(templateInfoResponseDto);
+    }
+
 
 }

--- a/src/main/java/org/autorepo/server/domain/template/controller/TemplateController.java
+++ b/src/main/java/org/autorepo/server/domain/template/controller/TemplateController.java
@@ -51,9 +51,9 @@ public class TemplateController {
         return SuccessResponse.ok(dashboardTemplateResponseDto);
     }
 
-    @GetMapping("/{type}/{templateId}")
-    public ResponseEntity<SuccessResponse<?>> getTemplateInfo(@PathVariable Long templateId, @PathVariable String type) {
-        TemplateInfoResponseDto templateInfoResponseDto = templateService.getTemplateInfo(templateId,type);
+    @GetMapping("/{type}/{id}")
+    public ResponseEntity<SuccessResponse<?>> getTemplateInfo(@PathVariable Long id, @PathVariable String type) {
+        TemplateInfoResponseDto templateInfoResponseDto = templateService.getTemplateInfo(id,type);
         return SuccessResponse.ok(templateInfoResponseDto);
     }
 

--- a/src/main/java/org/autorepo/server/domain/template/controller/TemplateController.java
+++ b/src/main/java/org/autorepo/server/domain/template/controller/TemplateController.java
@@ -8,6 +8,7 @@ import org.autorepo.server.domain.template.dto.response.TemplateListResponseDto;
 import org.autorepo.server.domain.template.entity.TemplateType;
 import org.autorepo.server.domain.template.service.TemplateService;
 import org.autorepo.server.global.common.SuccessResponse;
+import org.autorepo.server.global.utils.MarkdownToImageConverter;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -20,6 +21,7 @@ import java.util.List;
 public class TemplateController {
 
     private final TemplateService templateService;
+    private final MarkdownToImageConverter markdownToImageConverter;
 
     @PostMapping("/upload")
     public ResponseEntity<SuccessResponse<?>> uploadTemplate(@RequestBody UploadTemplateRequestDto uploadTemplateRequestDto, @AuthenticationPrincipal Long userId) {
@@ -27,12 +29,14 @@ public class TemplateController {
         return SuccessResponse.created(null);
     }
 
+
     @PostMapping("/share")
     public ResponseEntity<SuccessResponse<?>> shareTemplate(@RequestBody ShareTemplateRequestDto shareTemplateRequestDto) {
-        templateService.saveTemplate(shareTemplateRequestDto);
+        // 마크다운 이미지 업로드
+        String imageUrl = markdownToImageConverter.convertMarkdownToImage(shareTemplateRequestDto.content(), shareTemplateRequestDto.title());
+        templateService.saveTemplate(shareTemplateRequestDto, imageUrl);
         return SuccessResponse.created(null);
     }
-
 
     @GetMapping("/{type}")
     public ResponseEntity<SuccessResponse<?>> getAllTemplate(@PathVariable TemplateType type) {

--- a/src/main/java/org/autorepo/server/domain/template/dto/response/RandomTemplateResponseDto.java
+++ b/src/main/java/org/autorepo/server/domain/template/dto/response/RandomTemplateResponseDto.java
@@ -1,8 +1,9 @@
 package org.autorepo.server.domain.template.dto.response;
 
 public record RandomTemplateResponseDto(
+        Long templateId,
         String type,
         String title,
-        String content
+        String imageUrl
 ) {
 }

--- a/src/main/java/org/autorepo/server/domain/template/dto/response/RandomTemplateResponseDto.java
+++ b/src/main/java/org/autorepo/server/domain/template/dto/response/RandomTemplateResponseDto.java
@@ -1,7 +1,7 @@
 package org.autorepo.server.domain.template.dto.response;
 
 public record RandomTemplateResponseDto(
-        Long templateId,
+        Long id,
         String type,
         String title,
         String imageUrl

--- a/src/main/java/org/autorepo/server/domain/template/dto/response/RecentTemplateResponseDto.java
+++ b/src/main/java/org/autorepo/server/domain/template/dto/response/RecentTemplateResponseDto.java
@@ -3,10 +3,13 @@ package org.autorepo.server.domain.template.dto.response;
 import java.time.LocalDateTime;
 
 public record RecentTemplateResponseDto(
-        LocalDateTime modifiedAt,
+        Long templateId,
         String type,
         String title,
-        String content
+        String imageUrl,
+        LocalDateTime modifiedAt
+
+
 ) {
 
 }

--- a/src/main/java/org/autorepo/server/domain/template/dto/response/RecentTemplateResponseDto.java
+++ b/src/main/java/org/autorepo/server/domain/template/dto/response/RecentTemplateResponseDto.java
@@ -3,7 +3,7 @@ package org.autorepo.server.domain.template.dto.response;
 import java.time.LocalDateTime;
 
 public record RecentTemplateResponseDto(
-        Long templateId,
+        Long id,
         String type,
         String title,
         String imageUrl,

--- a/src/main/java/org/autorepo/server/domain/template/dto/response/TemplateInfoResponseDto.java
+++ b/src/main/java/org/autorepo/server/domain/template/dto/response/TemplateInfoResponseDto.java
@@ -1,7 +1,7 @@
 package org.autorepo.server.domain.template.dto.response;
 
 public record TemplateInfoResponseDto(
-        Long templateId,
+        Long id,
         String type,
         String title,
         String content

--- a/src/main/java/org/autorepo/server/domain/template/dto/response/TemplateInfoResponseDto.java
+++ b/src/main/java/org/autorepo/server/domain/template/dto/response/TemplateInfoResponseDto.java
@@ -1,0 +1,9 @@
+package org.autorepo.server.domain.template.dto.response;
+
+public record TemplateInfoResponseDto(
+        Long templateId,
+        String type,
+        String title,
+        String content
+) {
+}

--- a/src/main/java/org/autorepo/server/domain/template/entity/Template.java
+++ b/src/main/java/org/autorepo/server/domain/template/entity/Template.java
@@ -17,6 +17,7 @@ public class Template extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long templateId;
     private String title;
+    private String imageUrl;
     @Enumerated(EnumType.STRING)
     private TemplateType type;
     @Column(columnDefinition = "TEXT")
@@ -25,8 +26,10 @@ public class Template extends BaseTimeEntity {
     @JoinColumn(name = "repo_id")
     private Repo repo;
 
-    public void updateContent(String title, String content) {
+
+    public void updateContent(String title, String content, String imageUrl) {
         this.title = title;
         this.content = content;
+        this.imageUrl = imageUrl;
     }
 }

--- a/src/main/java/org/autorepo/server/domain/template/service/TemplateService.java
+++ b/src/main/java/org/autorepo/server/domain/template/service/TemplateService.java
@@ -118,23 +118,24 @@ public class TemplateService {
         // 랜덤 템플릿
         List<RandomTemplateResponseDto> randomTemplates = combineTemplatesAndReadmes(allTemplates, allReadmes).stream()
                 .sorted((o1, o2) -> new Random().nextInt(3) - 1)
-                .limit(5)
                 .map(template -> new RandomTemplateResponseDto(
+                        template.templateId(),
                         template.type(),
                         template.title(),
-                        template.content()
+                        template.imageUrl()
+
                 ))
                 .toList();
 
         // 최근 템플릿
         List<RecentTemplateResponseDto> recentTemplates = combineTemplatesAndReadmes(myTemplates, myReadmes).stream()
                 .sorted(Comparator.comparing(RecentTemplateResponseDto::modifiedAt).reversed())
-                .limit(5)
                 .map(template -> new RecentTemplateResponseDto(
-                        template.modifiedAt(),
+                        template.templateId(),
                         template.type(),
                         template.title(),
-                        template.content()
+                        template.imageUrl(),
+                        template.modifiedAt()
                 ))
                 .toList();
 
@@ -146,17 +147,19 @@ public class TemplateService {
         List<RecentTemplateResponseDto> result = new ArrayList<>();
 
         templates.forEach(template -> result.add(new RecentTemplateResponseDto(
-                template.getModifiedAt(),
+                template.getTemplateId(),
                 template.getType().name(),
                 template.getTitle(),
-                template.getContent()
+                template.getImageUrl(),
+                template.getModifiedAt()
         )));
 
         readmes.forEach(readme -> result.add(new RecentTemplateResponseDto(
-                readme.getModifiedAt(),
+                readme.getReadmeId(),
                 "README",
                 readme.getTitle(),
-                readme.getContent()
+                readme.getImageUrl(),
+                readme.getModifiedAt()
         )));
 
         return result;

--- a/src/main/java/org/autorepo/server/domain/template/service/TemplateService.java
+++ b/src/main/java/org/autorepo/server/domain/template/service/TemplateService.java
@@ -123,7 +123,7 @@ public class TemplateService {
         List<RandomTemplateResponseDto> randomTemplates = combineTemplatesAndReadmes(allTemplates, allReadmes).stream()
                 .sorted((o1, o2) -> new Random().nextInt(3) - 1)
                 .map(template -> new RandomTemplateResponseDto(
-                        template.templateId(),
+                        template.id(),
                         template.type(),
                         template.title(),
                         template.imageUrl()
@@ -135,7 +135,7 @@ public class TemplateService {
         List<RecentTemplateResponseDto> recentTemplates = combineTemplatesAndReadmes(myTemplates, myReadmes).stream()
                 .sorted(Comparator.comparing(RecentTemplateResponseDto::modifiedAt).reversed())
                 .map(template -> new RecentTemplateResponseDto(
-                        template.templateId(),
+                        template.id(),
                         template.type(),
                         template.title(),
                         template.imageUrl(),
@@ -169,13 +169,13 @@ public class TemplateService {
         return result;
     }
 
-    public TemplateInfoResponseDto getTemplateInfo(Long templateId, String type) {
+    public TemplateInfoResponseDto getTemplateInfo(Long id, String type) {
         if (type.equals("README")) {
-            Readme readme = readmeRepository.findById(templateId)
+            Readme readme = readmeRepository.findById(id)
                     .orElseThrow(() -> new EntityNotFoundException(README_NOT_FOUND));
             return new TemplateInfoResponseDto(readme.getReadmeId(), "README", readme.getTitle(), readme.getContent());
         } else {
-            Template template = templateRepository.findById(templateId)
+            Template template = templateRepository.findById(id)
                     .orElseThrow(() -> new EntityNotFoundException(TEMPLATE_NOT_FOUND));
             return new TemplateInfoResponseDto(template.getTemplateId(), template.getType().name(), template.getTitle(), template.getContent());
         }

--- a/src/main/java/org/autorepo/server/domain/template/service/TemplateService.java
+++ b/src/main/java/org/autorepo/server/domain/template/service/TemplateService.java
@@ -5,7 +5,7 @@ import org.autorepo.server.domain.readme.entity.Readme;
 import org.autorepo.server.domain.readme.repository.ReadmeRepository;
 import org.autorepo.server.domain.repo.entity.Repo;
 import org.autorepo.server.domain.repo.repository.RepoRepository;
-import org.autorepo.server.domain.repo.service.GitHubService;
+import org.autorepo.server.global.utils.GitHubService;
 import org.autorepo.server.domain.template.dto.request.ShareTemplateRequestDto;
 import org.autorepo.server.domain.template.dto.request.UploadTemplateRequestDto;
 import org.autorepo.server.domain.template.dto.response.DashboardTemplateResponseDto;
@@ -69,16 +69,15 @@ public class TemplateService {
     }
 
     // 템플릿 저장
-    public void saveTemplate(ShareTemplateRequestDto shareTemplateRequestDto) {
+    public void saveTemplate(ShareTemplateRequestDto shareTemplateRequestDto, String imageUrl) {
 
         Repo repo = repoRepository.findByRepoUrl(shareTemplateRequestDto.repoUrl())
                 .orElseThrow(() -> new IllegalArgumentException(ErrorCode.REPO_NOT_FOUND.getMessage()));
 
         Template existingTemplate = templateRepository.findByRepoAndType(repo, shareTemplateRequestDto.type())
                 .orElse(null);
-
         if (existingTemplate != null) {
-            existingTemplate.updateContent(shareTemplateRequestDto.title(), shareTemplateRequestDto.content());
+            existingTemplate.updateContent(shareTemplateRequestDto.title(), shareTemplateRequestDto.content(), imageUrl);
             templateRepository.save(existingTemplate);
         } else {
             // 새로운 템플릿 생성
@@ -87,6 +86,7 @@ public class TemplateService {
                     .title(shareTemplateRequestDto.title())
                     .content(shareTemplateRequestDto.content())
                     .type(shareTemplateRequestDto.type())
+                    .imageUrl(imageUrl)
                     .build();
 
             templateRepository.save(newTemplate);

--- a/src/main/java/org/autorepo/server/domain/template/service/TemplateService.java
+++ b/src/main/java/org/autorepo/server/domain/template/service/TemplateService.java
@@ -1,30 +1,34 @@
 package org.autorepo.server.domain.template.service;
 
+
 import lombok.RequiredArgsConstructor;
 import org.autorepo.server.domain.readme.entity.Readme;
 import org.autorepo.server.domain.readme.repository.ReadmeRepository;
 import org.autorepo.server.domain.repo.entity.Repo;
 import org.autorepo.server.domain.repo.repository.RepoRepository;
-import org.autorepo.server.global.utils.GitHubService;
 import org.autorepo.server.domain.template.dto.request.ShareTemplateRequestDto;
 import org.autorepo.server.domain.template.dto.request.UploadTemplateRequestDto;
-import org.autorepo.server.domain.template.dto.response.DashboardTemplateResponseDto;
-import org.autorepo.server.domain.template.dto.response.RandomTemplateResponseDto;
-import org.autorepo.server.domain.template.dto.response.RecentTemplateResponseDto;
-import org.autorepo.server.domain.template.dto.response.TemplateListResponseDto;
+import org.autorepo.server.domain.template.dto.response.*;
 import org.autorepo.server.domain.template.entity.Template;
 import org.autorepo.server.domain.template.entity.TemplateType;
 import org.autorepo.server.domain.template.repository.TemplateRepository;
 import org.autorepo.server.domain.user.entity.User;
 import org.autorepo.server.domain.user.repository.UserRepository;
-import org.autorepo.server.global.error.ErrorCode;
+import org.autorepo.server.global.error.exception.EntityNotFoundException;
+import org.autorepo.server.global.error.exception.InternalServerException;
+import org.autorepo.server.global.utils.GitHubService;
 import org.json.JSONObject;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Service;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Random;
 import java.util.stream.Collectors;
+
+import static org.autorepo.server.global.error.ErrorCode.*;
 
 @RequiredArgsConstructor
 @Service
@@ -41,7 +45,7 @@ public class TemplateService {
     // 템플릿 업로드
     public void uploadTemplate(UploadTemplateRequestDto uploadTemplateRequestDto, Long userId) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.USER_NOT_FOUND.getMessage()));
+                .orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));
 
         // PR/ISSUE 템플릿 구분
         boolean isPR = uploadTemplateRequestDto.type() == TemplateType.PR;
@@ -64,7 +68,7 @@ public class TemplateService {
             }
             gitHubService.sendRequest(url, HttpMethod.PUT, headers, jsonBody.toString());
         } catch (Exception e) {
-            throw new RuntimeException(ErrorCode.GITHUB_TEMPLATE_UPLOAD_ERROR.getMessage(), e);
+            throw new InternalServerException(GITHUB_TEMPLATE_UPLOAD_ERROR);
         }
     }
 
@@ -72,7 +76,7 @@ public class TemplateService {
     public void saveTemplate(ShareTemplateRequestDto shareTemplateRequestDto, String imageUrl) {
 
         Repo repo = repoRepository.findByRepoUrl(shareTemplateRequestDto.repoUrl())
-                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.REPO_NOT_FOUND.getMessage()));
+                .orElseThrow(() -> new EntityNotFoundException(REPO_NOT_FOUND));
 
         Template existingTemplate = templateRepository.findByRepoAndType(repo, shareTemplateRequestDto.type())
                 .orElse(null);
@@ -104,7 +108,7 @@ public class TemplateService {
     // 대시보드 템플릿 조회
     public DashboardTemplateResponseDto getDashBoardTemplates(Long userId) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.USER_NOT_FOUND.getMessage()));
+                .orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));
 
         // 전체 템플릿 리드미
         List<Template> allTemplates = templateRepository.findAll();
@@ -165,4 +169,17 @@ public class TemplateService {
         return result;
     }
 
+    public TemplateInfoResponseDto getTemplateInfo(Long templateId, String type) {
+        if (type.equals("README")) {
+            Readme readme = readmeRepository.findById(templateId)
+                    .orElseThrow(() -> new EntityNotFoundException(README_NOT_FOUND));
+            return new TemplateInfoResponseDto(readme.getReadmeId(), "README", readme.getTitle(), readme.getContent());
+        } else {
+            Template template = templateRepository.findById(templateId)
+                    .orElseThrow(() -> new EntityNotFoundException(TEMPLATE_NOT_FOUND));
+            return new TemplateInfoResponseDto(template.getTemplateId(), template.getType().name(), template.getTitle(), template.getContent());
+        }
+
+
+    }
 }

--- a/src/main/java/org/autorepo/server/global/config/S3Config.java
+++ b/src/main/java/org/autorepo/server/global/config/S3Config.java
@@ -1,0 +1,33 @@
+package org.autorepo.server.global.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${aws-property.access-key}")
+    private String accessKey;
+
+    @Value("${aws-property.secret-key}")
+    private String secretKey;
+
+    @Value("${aws-property.aws-region}")
+    private String region;
+
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+
+}

--- a/src/main/java/org/autorepo/server/global/error/ErrorCode.java
+++ b/src/main/java/org/autorepo/server/global/error/ErrorCode.java
@@ -31,6 +31,8 @@ public enum ErrorCode {
     REPO_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 레포지토리를 찾을 수 없습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 유저를 찾을 수 없습니다."),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "리프레쉬 토큰을 찾을 수 없습니다."),
+    TEMPLATE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 템플릿을 찾을 수 없습니다."),
+    README_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 README를 찾을 수 없습니다."),
 
     /**
      * 405 Method Not Allowed
@@ -52,6 +54,7 @@ public enum ErrorCode {
      * 500 Internal Server Error
      */
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
+    REPO_PARSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "레포지토리 파싱 중 오류가 발생했습니다."),
     GITHUB_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "GitHub API 호출 중 오류가 발생했습니다."),
     GITHUB_LABEL_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "깃허브 기존 라벨 삭제 중 오류가 발생했습니다."),
     GITHUB_LABEL_CREATE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "깃허브 라벨 생성 중 오류가 발생했습니다."),

--- a/src/main/java/org/autorepo/server/global/error/exception/EntityNotFoundException.java
+++ b/src/main/java/org/autorepo/server/global/error/exception/EntityNotFoundException.java
@@ -1,0 +1,8 @@
+package org.autorepo.server.global.error.exception;
+
+
+import org.autorepo.server.global.error.ErrorCode;
+
+public class EntityNotFoundException extends BusinessException {
+    public EntityNotFoundException(ErrorCode errorCode) {super(errorCode);}
+}

--- a/src/main/java/org/autorepo/server/global/utils/GitHubService.java
+++ b/src/main/java/org/autorepo/server/global/utils/GitHubService.java
@@ -1,4 +1,4 @@
-package org.autorepo.server.domain.repo.service;
+package org.autorepo.server.global.utils;
 
 import lombok.RequiredArgsConstructor;
 import org.autorepo.server.global.error.ErrorCode;

--- a/src/main/java/org/autorepo/server/global/utils/GitHubService.java
+++ b/src/main/java/org/autorepo/server/global/utils/GitHubService.java
@@ -2,6 +2,7 @@ package org.autorepo.server.global.utils;
 
 import lombok.RequiredArgsConstructor;
 import org.autorepo.server.global.error.ErrorCode;
+import org.autorepo.server.global.error.exception.InternalServerException;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -9,6 +10,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.client.HttpClientErrorException;
+
+import static org.autorepo.server.global.error.ErrorCode.*;
 
 @RequiredArgsConstructor
 @Service
@@ -19,7 +22,8 @@ public class GitHubService {
     public String[] parseRepositoryUrl(String repoUrl) {
         String[] parts = repoUrl.split("/");
         if (parts.length < 5) {
-            throw new IllegalArgumentException(ErrorCode.BAD_REQUEST.getMessage());
+            throw new InternalServerException(REPO_PARSE_ERROR);
+
         }
         String owner = parts[3];
         String repo = parts[4].replace(".git", "");
@@ -40,7 +44,7 @@ public class GitHubService {
         try {
             return restTemplate.exchange(url, method, request, String.class);
         } catch (HttpClientErrorException e) {
-            throw new RuntimeException(ErrorCode.GITHUB_API_ERROR.getMessage() + ": " + e.getMessage(), e);
+            throw new InternalServerException(GITHUB_API_ERROR);
         }
     }
 
@@ -52,7 +56,7 @@ public class GitHubService {
                 return new org.json.JSONObject(response.getBody()).getString("sha");
             }
         } catch (Exception e) {
-            throw new RuntimeException(ErrorCode.UNPROCESSABLE_ENTITY.getMessage(), e);
+            throw new InternalServerException(UNPROCESSABLE_ENTITY);
         }
         return null;
     }

--- a/src/main/java/org/autorepo/server/global/utils/MarkdownToImageConverter.java
+++ b/src/main/java/org/autorepo/server/global/utils/MarkdownToImageConverter.java
@@ -1,0 +1,85 @@
+package org.autorepo.server.global.utils;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import lombok.RequiredArgsConstructor;
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.html.HtmlRenderer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.imageio.ImageIO;
+import javax.swing.*;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
+@RequiredArgsConstructor
+@Service
+public class MarkdownToImageConverter {
+
+    private final AmazonS3 s3Client;
+
+    @Value("${aws-property.s3-bucket-name}")
+    private String bucketName;
+
+    private static final int IMAGE_WIDTH = 400;
+    private static final int IMAGE_HEIGHT = 300;
+
+    public String convertMarkdownToImage(String markdownContent, String title) {
+        try {
+            // 1. Markdown -> HTML 변환
+            String htmlContent = HtmlRenderer.builder()
+                    .build()
+                    .render(Parser.builder().build().parse(markdownContent));
+
+            // 2. HTML -> BufferedImage 변환
+            BufferedImage image = renderHtmlToImage(htmlContent);
+
+            // 3. BufferedImage -> S3 업로드
+            return uploadImageToS3(image, title);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to process and upload Markdown as image", e);
+        }
+    }
+
+    // HTML -> Image 변환
+    private BufferedImage renderHtmlToImage(String htmlContent) {
+        JEditorPane editorPane = new JEditorPane();
+        editorPane.setContentType("text/html");
+        editorPane.setText(htmlContent);
+        editorPane.setSize(IMAGE_WIDTH, IMAGE_HEIGHT);
+        editorPane.setFont(new Font("Malgun Gothic", Font.PLAIN, 14));
+        editorPane.setEditable(false);
+
+        BufferedImage image = new BufferedImage(IMAGE_WIDTH, IMAGE_HEIGHT, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D graphics = image.createGraphics();
+        graphics.setColor(Color.WHITE);
+        graphics.fillRect(0, 0, IMAGE_WIDTH, IMAGE_HEIGHT);
+        editorPane.paint(graphics);
+        graphics.dispose();
+
+        return image;
+    }
+
+    // S3에 이미지 업로드
+    private String uploadImageToS3(BufferedImage image, String title) {
+        String fileName = "markdown-images/" + title + "-" + System.currentTimeMillis() + ".png";
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            ImageIO.write(image, "png", baos);
+            byte[] imageBytes = baos.toByteArray();
+
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setContentType("image/png");
+            metadata.setContentLength(imageBytes.length);
+
+            try (ByteArrayInputStream inputStream = new ByteArrayInputStream(imageBytes)) {
+                s3Client.putObject(bucketName, fileName, inputStream, metadata);
+            }
+            return s3Client.getUrl(bucketName, fileName).toString();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to upload image to S3", e);
+        }
+    }
+}

--- a/src/main/java/org/autorepo/server/global/utils/MarkdownToImageConverter.java
+++ b/src/main/java/org/autorepo/server/global/utils/MarkdownToImageConverter.java
@@ -2,18 +2,17 @@ package org.autorepo.server.global.utils;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.vladsch.flexmark.html.HtmlRenderer;
+import com.vladsch.flexmark.parser.Parser;
 import lombok.RequiredArgsConstructor;
-import org.commonmark.parser.Parser;
-import org.commonmark.renderer.html.HtmlRenderer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.xhtmlrenderer.swing.Java2DRenderer;
 
 import javax.imageio.ImageIO;
-import javax.swing.*;
 import java.awt.*;
 import java.awt.image.BufferedImage;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
+import java.io.*;
 
 @RequiredArgsConstructor
 @Service
@@ -26,49 +25,86 @@ public class MarkdownToImageConverter {
 
     private static final int IMAGE_WIDTH = 400;
     private static final int IMAGE_HEIGHT = 300;
+    private final MarkdownToImageUserAgent markdownToImageUserAgent = new MarkdownToImageUserAgent();
 
+    // 마크다운을 이미지로 변환
     public String convertMarkdownToImage(String markdownContent, String title) {
         try {
-            // 1. Markdown -> HTML 변환
-            String htmlContent = HtmlRenderer.builder()
-                    .build()
-                    .render(Parser.builder().build().parse(markdownContent));
-
-            // 2. HTML -> BufferedImage 변환
-            BufferedImage image = renderHtmlToImage(htmlContent);
-
-            // 3. BufferedImage -> S3 업로드
-            return uploadImageToS3(image, title);
+            String xhtmlContent = generateXHTML(markdownContent);
+            BufferedImage renderedImage = renderHtmlToImage(xhtmlContent);
+            BufferedImage croppedImage = cropToFixedSize(renderedImage);
+            return uploadImageToS3(croppedImage, title);
         } catch (Exception e) {
             throw new RuntimeException("Failed to process and upload Markdown as image", e);
         }
     }
 
-    // HTML -> Image 변환
-    private BufferedImage renderHtmlToImage(String htmlContent) {
-        JEditorPane editorPane = new JEditorPane();
-        editorPane.setContentType("text/html");
-        editorPane.setText(htmlContent);
-        editorPane.setSize(IMAGE_WIDTH, IMAGE_HEIGHT);
-        editorPane.setFont(new Font("Malgun Gothic", Font.PLAIN, 14));
-        editorPane.setEditable(false);
+    // 1. 마크다운을 XHTML로 변환
+    private String generateXHTML(String markdownContent) {
+        String htmlBody = HtmlRenderer.builder().build()
+                .render(Parser.builder().build().parse(markdownContent));
 
-        BufferedImage image = new BufferedImage(IMAGE_WIDTH, IMAGE_HEIGHT, BufferedImage.TYPE_INT_ARGB);
-        Graphics2D graphics = image.createGraphics();
-        graphics.setColor(Color.WHITE);
-        graphics.fillRect(0, 0, IMAGE_WIDTH, IMAGE_HEIGHT);
-        editorPane.paint(graphics);
-        graphics.dispose();
-
-        return image;
+        return """
+                <!DOCTYPE html>
+                <html xmlns="http://www.w3.org/1999/xhtml">
+                <head>
+                    <meta charset="UTF-8" />
+                    <style>
+                        body { font-family: 'Arial', sans-serif; font-size: 14px; line-height: 1.6; margin: 0; padding: 0; }
+                        table { border-collapse: collapse; width: 100%; }
+                        th, td { border: 1px solid #ddd; padding: 8px; }
+                        th { background-color: #f2f2f2; text-align: left; }
+                        img { max-width: 100%; height: auto; }
+                    </style>
+                </head>
+                <body>""" + sanitizeHtml(htmlBody) + "</body></html>";
     }
 
-    // S3에 이미지 업로드
+    private String sanitizeHtml(String htmlContent) {
+        return htmlContent
+                .replace("<br>", "<br />")
+                .replace("<img ", "<img ")
+                .replace("<hr>", "<hr />")
+                .replace("<meta ", "<meta ")
+                .replace("<link ", "<link />");
+    }
+
+    // 2. HTML을 이미지로 렌더링
+    private BufferedImage renderHtmlToImage(String htmlContent) throws IOException {
+        File tempFile = File.createTempFile("tempHtml", ".html");
+        try (FileWriter writer = new FileWriter(tempFile)) {
+            writer.write(htmlContent);
+        }
+
+        try {
+            Java2DRenderer renderer = new Java2DRenderer(tempFile, IMAGE_WIDTH, IMAGE_HEIGHT);
+            renderer.getSharedContext().setUserAgentCallback(markdownToImageUserAgent);
+            renderer.setBufferedImageType(BufferedImage.TYPE_INT_ARGB);
+            return renderer.getImage();
+        } finally {
+            if (tempFile.exists()) {
+                tempFile.delete();
+            }
+        }
+    }
+
+    // 이미지 크기 조정
+    private BufferedImage cropToFixedSize(BufferedImage originalImage) {
+        BufferedImage croppedImage = new BufferedImage(IMAGE_WIDTH, IMAGE_HEIGHT, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D graphics = croppedImage.createGraphics();
+        graphics.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+        graphics.drawImage(originalImage, 0, 0, IMAGE_WIDTH, IMAGE_HEIGHT, null);
+        graphics.dispose();
+        return croppedImage;
+    }
+
+    // 3. S3에 이미지 업로드
     private String uploadImageToS3(BufferedImage image, String title) {
         String fileName = "markdown-images/" + title + "-" + System.currentTimeMillis() + ".png";
-        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
-            ImageIO.write(image, "png", baos);
-            byte[] imageBytes = baos.toByteArray();
+
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            ImageIO.write(image, "png", outputStream);
+            byte[] imageBytes = outputStream.toByteArray();
 
             ObjectMetadata metadata = new ObjectMetadata();
             metadata.setContentType("image/png");
@@ -78,7 +114,7 @@ public class MarkdownToImageConverter {
                 s3Client.putObject(bucketName, fileName, inputStream, metadata);
             }
             return s3Client.getUrl(bucketName, fileName).toString();
-        } catch (Exception e) {
+        } catch (IOException e) {
             throw new RuntimeException("Failed to upload image to S3", e);
         }
     }

--- a/src/main/java/org/autorepo/server/global/utils/MarkdownToImageUserAgent.java
+++ b/src/main/java/org/autorepo/server/global/utils/MarkdownToImageUserAgent.java
@@ -1,0 +1,28 @@
+package org.autorepo.server.global.utils;
+
+import org.xhtmlrenderer.swing.NaiveUserAgent;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.net.URL;
+
+// 외부 URL에서 이미지를 다운로드
+public class MarkdownToImageUserAgent extends NaiveUserAgent {
+    @Override
+    public byte[] getBinaryResource(String uri) {
+        try {
+            URL url = new URL(uri);
+            try (InputStream inputStream = url.openStream(); ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+                byte[] buffer = new byte[1024];
+                int bytesRead;
+                while ((bytesRead = inputStream.read(buffer)) != -1) {
+                    outputStream.write(buffer, 0, bytesRead);
+                }
+                return outputStream.toByteArray();
+            }
+        } catch (Exception e) {
+            System.err.println("Failed to load resource: " + uri);
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## 관련 이슈

- Resolves : #18

## 작업 사항

- 대시보드 조회 뷰 수정 (기존 마크다운 content반환 -> 이미지 반환)
<img width="832" alt="스크린샷 2024-11-29 01 05 49" src="https://github.com/user-attachments/assets/7e7ab4e8-7241-4309-8792-c15e4c141af3">

- 대시보드 디테일 템플릿  조회 뷰 구현
<img width="870" alt="스크린샷 2024-11-29 01 06 49" src="https://github.com/user-attachments/assets/c413b270-2286-406c-91b7-3e0e99900c62">

- PR/ISSUE 업로드 될때 미리보기 이미지 S3 업로드 구현
![image](https://github.com/user-attachments/assets/d1c3a0be-be46-4e49-9022-89322ebc5c68)

## 참고 사항

BE
- FE랑 이야기 했을 때 대시보드 조회에서 미리보기뷰 반환하기로해서 README와 Template엔티티에 imageUrl필드 추가했습니다.
- 전에 작성했던 깃허브 업로드 관련 코드들 repo도메인 -> Utils 디렉토리로 옮겼습니다
- 엔티티 못찾았을 때 발상하는 예외 관련 에러 핸들러 추가했습니다
- Utils 디렉토리에 MarkdownToImageConverter : previw 만들어주는 클래스인데(마크다운 -> html -> 이미지 s3업로드) issue/pr은 비교적 잘 나오는데 Readme처럼 길어지거나 표같은 서식이 많아지면 결과가 불완전한 느낌? 여튼 리드미 관련 API 구현하실 때 활용할 수 있을 거 같아서 공유드립니다.

