### PR TITLE
#25 [FIX] 템플릿 업로드 할 때 SHA가 null일 때, 새로운 레포일 때 처리 로직 추가

### DIFF
--- a/src/main/java/org/autorepo/server/domain/template/service/TemplateService.java
+++ b/src/main/java/org/autorepo/server/domain/template/service/TemplateService.java
@@ -42,55 +42,66 @@ public class TemplateService {
 
 
 // 템플릿 업로드
-    public void uploadTemplate(UploadTemplateRequestDto uploadTemplateRequestDto, Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));
+public void uploadTemplate(UploadTemplateRequestDto uploadTemplateRequestDto, Long userId) {
+    User user = userRepository.findById(userId)
+            .orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));
 
-        // PR/ISSUE 템플릿 구분
-        boolean isPR = uploadTemplateRequestDto.type() == TemplateType.PR;
-        String metaContent = "---\nname: Issue template\nabout: Issue template\ntitle: ''\nlabels: ''\nassignees: ''\n---";
-        String content = isPR ? uploadTemplateRequestDto.content() : metaContent + "\n" + uploadTemplateRequestDto.content();
-        String path = isPR ? ".github/pull_request_template.md" : ".github/ISSUE_TEMPLATE/issue_template.md";
+    // PR/ISSUE 템플릿 구분
+    boolean isPR = uploadTemplateRequestDto.type() == TemplateType.PR;
+    String metaContent = "---\nname: Issue template\nabout: Issue template\ntitle: ''\nlabels: ''\nassignees: ''\n---";
+    String content = isPR ? uploadTemplateRequestDto.content() : metaContent + "\n" + uploadTemplateRequestDto.content();
+    String path = isPR ? ".github/pull_request_template.md" : ".github/ISSUE_TEMPLATE/issue_template.md";
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.set("Authorization", "Bearer " + user.getGithubToken());
-        String url = gitHubService.createGitHubApiUrl(GITHUB_API_URL, uploadTemplateRequestDto.repoUrl(), path, headers, user.getGithubToken());
-        String base64Content = java.util.Base64.getEncoder().encodeToString(content.getBytes());
-        JSONObject jsonBody = new JSONObject();
-        jsonBody.put("message", "Update " + uploadTemplateRequestDto.type() + " Template");
-        jsonBody.put("content", base64Content);
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("Authorization", "Bearer " + user.getGithubToken());
 
+    // GitHub API URL 생성
+    String url = gitHubService.createGitHubApiUrl(GITHUB_API_URL, uploadTemplateRequestDto.repoUrl(), path, headers, user.getGithubToken());
+
+    // 파일 Base64 인코딩
+    String base64Content = java.util.Base64.getEncoder().encodeToString(content.getBytes());
+    JSONObject jsonBody = new JSONObject();
+    jsonBody.put("message", "Update " + uploadTemplateRequestDto.type() + " Template");
+    jsonBody.put("content", base64Content);
+
+    try {
+        // 기존 파일 SHA 확인
+        String sha = null;
         try {
-            String sha = null;
-            try {
-                sha = gitHubService.getFileSha(url, headers);
-            } catch (HttpClientErrorException.NotFound e) {
-                System.out.println("기존 파일이 존재하지 않습니다. 새로 생성합니다.");
-            }
-            if (sha != null) {
-                jsonBody.put("sha", sha);
-            }
-            gitHubService.sendRequest(url, HttpMethod.PUT, headers, jsonBody.toString());
-        } catch (Exception e) {
-            throw new InternalServerException(GITHUB_TEMPLATE_UPLOAD_ERROR);
+            sha = gitHubService.getFileSha(url, headers);
+        } catch (HttpClientErrorException.NotFound e) {
+            System.out.println("기존 파일이 존재하지 않습니다. 새로 생성합니다.");
         }
+        // 기존 파일이 존재하면 SHA를 포함하여 업데이트, 존재하지 않으면 새로 생성
+        if (sha != null) {
+            jsonBody.put("sha", sha);  // 기존 파일을 수정하는 경우 SHA를 포함
+        }
+
+        // GitHub API로 요청 전송
+        gitHubService.sendRequest(url, HttpMethod.PUT, headers, jsonBody.toString());
+    } catch (Exception e) {
+        // 예외 발생 시 처리
+        System.out.println("GitHub API 호출 실패: " + e.getMessage());
+        throw new InternalServerException(GITHUB_TEMPLATE_UPLOAD_ERROR);
     }
+}
 
-        // 템플릿 저장
-        public void saveTemplate(ShareTemplateRequestDto shareTemplateRequestDto, String imageUrl) {
-            Repo repo = repoRepository.findByRepoUrl(shareTemplateRequestDto.repoUrl())
-                    .orElseThrow(() -> new EntityNotFoundException(REPO_NOT_FOUND));
 
-            Template newTemplate = Template.builder()
-                    .repo(repo)
-                    .title(shareTemplateRequestDto.title())
-                    .content(shareTemplateRequestDto.content())
-                    .type(shareTemplateRequestDto.type())
-                    .imageUrl(imageUrl)
-                    .build();
+    // 템플릿 저장
+    public void saveTemplate(ShareTemplateRequestDto shareTemplateRequestDto, String imageUrl) {
+        Repo repo = repoRepository.findByRepoUrl(shareTemplateRequestDto.repoUrl())
+                .orElseThrow(() -> new EntityNotFoundException(REPO_NOT_FOUND));
 
-            templateRepository.save(newTemplate);
-        }
+        Template newTemplate = Template.builder()
+                .repo(repo)
+                .title(shareTemplateRequestDto.title())
+                .content(shareTemplateRequestDto.content())
+                .type(shareTemplateRequestDto.type())
+                .imageUrl(imageUrl)
+                .build();
+
+        templateRepository.save(newTemplate);
+    }
 
 
 

--- a/src/main/java/org/autorepo/server/global/utils/GitHubService.java
+++ b/src/main/java/org/autorepo/server/global/utils/GitHubService.java
@@ -44,35 +44,46 @@ public class GitHubService {
         HttpEntity<String> request = new HttpEntity<>(body, headers);
         try {
             return restTemplate.exchange(url, method, request, String.class);
+
         } catch (HttpClientErrorException e) {
             System.out.println("GitHub API 요청 실패: " + e.getMessage());
             System.out.println("응답 코드: " + e.getStatusCode());
             System.out.println("응답 본문: " + e.getResponseBodyAsString());
+            if (e.getStatusCode() == HttpStatus.NOT_FOUND) {
+                System.out.println("404 오류 발생: 파일을 찾을 수 없습니다. 새로운 파일을 업로드 할 예정입니다.");
+                return null;
+            }
 
             throw new InternalServerException(GITHUB_API_ERROR);
         }
     }
 
-    // GitHub API로 SHA 조회(기존 값 존재 유무 확인)
-    public String getFileSha(String url, HttpHeaders headers) {
-        try {
-            ResponseEntity<String> response = sendRequest(url, HttpMethod.GET, headers, null);
-            if (response.getStatusCode().is2xxSuccessful()) {
-                return new org.json.JSONObject(response.getBody()).getString("sha");
-            }
-        } catch (HttpClientErrorException e) {
-            if (e.getStatusCode() == HttpStatus.NOT_FOUND) {
-                System.out.println("File not found. ");
-                return null; // 파일이 없는 경우 null 반환
-            }
-            throw new InternalServerException(UNPROCESSABLE_ENTITY);
-        } catch (Exception e) {
-            System.out.println("Unexpected error: " + e.getMessage());
-            throw new InternalServerException(UNPROCESSABLE_ENTITY);
-        }
+// GitHub API로 SHA 조회(기존 값 존재 유무 확인)
+public String getFileSha(String url, HttpHeaders headers) {
+    try {
+        ResponseEntity<String> response = sendRequest(url, HttpMethod.GET, headers, null);
 
-        return null;
+        // 응답이 없거나, 상태 코드가 성공적이지 않으면 null 반환
+        if (response == null || !response.getStatusCode().is2xxSuccessful()) {
+            System.out.println("File not found or repository is empty.");
+            return null; // 파일이 없거나 비어있는 경우 null 반환
+        }
+        // 정상 응답이면 SHA 값 반환
+        return new org.json.JSONObject(response.getBody()).getString("sha");
+    } catch (HttpClientErrorException e) {
+        // 404 오류가 발생하면 파일이 없다는 의미로 처리
+        if (e.getStatusCode() == HttpStatus.NOT_FOUND) {
+            System.out.println("File not found. Proceeding with new file upload.");
+            return null; // 파일이 없으면 null 반환
+        }
+        // 그 외의 오류 처리
+        throw new InternalServerException(UNPROCESSABLE_ENTITY);
+    } catch (Exception e) {
+        System.out.println("Unexpected error: " + e.getMessage());
+        throw new InternalServerException(UNPROCESSABLE_ENTITY);
     }
+}
+
 
 
 //    public String getUsernameFromPAT(String token) {


### PR DESCRIPTION
## 관련 이슈 

- Resolves : #25

## 작업 사항

문제 상황 
 getFileSha 함수에서 GitHub API 호출 (sendRequest 함수) -> 비어 있는 레포지토리나 파일이 없을 때 발생하는 404 응답을 제대로 처리하지 못하고 예외를 던짐 (아마 GitHub api를 처음 요청하는 레포도 비어있는 레포(404)로 읽는 거 같은데 이게 문제였던 거 같음)

해결 방법:
sendRequest에서 비어 있는 레포(404) 로 가져올 때 null 처리 
비어 있는 레포지토리나 파일이 없는 경우에도 오류가 아닌 새로운 파일 업로드로 진행되도록 처리

BE 전달사항
Utils에 있는 코드 건드린거라! (GithubService) 리드미 관련 코드에 호옥시 영향이 있다면 말씀해주세욤
